### PR TITLE
(very) simple bug fix for screenshot method

### DIFF
--- a/stagehand/page.py
+++ b/stagehand/page.py
@@ -399,7 +399,7 @@ class StagehandPage:
 
             return result
         else:
-            return await self._page.screenshot(**options)
+            return await self._page.screenshot(**payload)
 
     # Method to get or initialize the persistent CDP client
     async def get_cdp_client(self) -> CDPSession:

--- a/stagehand/page.py
+++ b/stagehand/page.py
@@ -399,7 +399,7 @@ class StagehandPage:
 
             return result
         else:
-            return await self._page.screenshot(options)
+            return await self._page.screenshot(**options)
 
     # Method to get or initialize the persistent CDP client
     async def get_cdp_client(self) -> CDPSession:


### PR DESCRIPTION
unpack the input options as the base playwright `screenshot` method accepts keyword arguments only

# why
can't use the `screenshot` function bc of this bug when on local env

# what changed
simple unpacking for arguments to comply to base playwright `screenshot` method that accepts keyword arguments only

https://github.com/microsoft/playwright-python/blob/0ff7fc983ef39ed6121ffbac4eaf15e9b02a6aba/playwright/async_api/_generated.py#L2768

# test plan
regular (?) 