### PR TITLE
update for ci for externals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,8 +87,7 @@ jobs:
           --tb=short \
           --maxfail=5
       env:
-        MODEL_API_KEY: ${{ secrets.MODEL_API_KEY || 'mock-model-key' }}
-        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'mock-openai-key' }}
+        MODEL_API_KEY: ${{ secrets.MODEL_API_KEY }}
         DISPLAY: ":99"
     
     - name: Upload integration test results

--- a/tests/integration/local/test_core_local.py
+++ b/tests/integration/local/test_core_local.py
@@ -42,6 +42,10 @@ class TestStagehandLocalIntegration:
     @pytest.mark.asyncio
     @pytest.mark.integration
     @pytest.mark.local
+    @pytest.mark.skipif(
+        not os.getenv("MODEL_API_KEY"),
+        reason="MODEL_API_KEY not available - skipping test that requires API access"
+    )
     async def test_local_observe_and_act_workflow(self, stagehand_local):
         """Test core observe and act workflow in LOCAL mode - extracted from e2e tests."""
         stagehand = stagehand_local
@@ -79,6 +83,10 @@ class TestStagehandLocalIntegration:
     @pytest.mark.asyncio
     @pytest.mark.integration
     @pytest.mark.local
+    @pytest.mark.skipif(
+        not os.getenv("MODEL_API_KEY"),
+        reason="MODEL_API_KEY not available - skipping test that requires API access"
+    )
     async def test_local_basic_navigation_and_observe(self, stagehand_local):
         """Test basic navigation and observe functionality in LOCAL mode"""
         stagehand = stagehand_local
@@ -101,6 +109,10 @@ class TestStagehandLocalIntegration:
     @pytest.mark.asyncio
     @pytest.mark.integration
     @pytest.mark.local
+    @pytest.mark.skipif(
+        not os.getenv("MODEL_API_KEY"),
+        reason="MODEL_API_KEY not available - skipping test that requires API access"
+    )
     async def test_local_extraction_functionality(self, stagehand_local):
         """Test extraction functionality in LOCAL mode"""
         stagehand = stagehand_local


### PR DESCRIPTION
# why
External contributors are unable to pass CI for tests where secrets are needed.

# what changed
Update tests to skip tests with secrets. This needs to be then run by a contributor.

# test plan
