### PR TITLE
fix bug on api_url load from .env

### DIFF
--- a/stagehand/config.py
+++ b/stagehand/config.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Callable, Literal, Optional
 
 from browserbase.types import SessionCreateParams as BrowserbaseSessionCreateParams
@@ -42,7 +43,7 @@ class StagehandConfig(BaseModel):
         None, alias="projectId", description="Browserbase project ID"
     )
     api_url: Optional[str] = Field(
-        "https://api.stagehand.browserbase.com/v1",
+        os.environ.get("STAGEHAND_API_URL", "https://api.stagehand.browserbase.com/v1"),
         alias="apiUrl",
         description="Stagehand API URL",
     )

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -67,7 +67,7 @@ class Stagehand:
             self.config = config
 
         # Handle non-config parameters
-        self.api_url = self.config.api_url or os.getenv("STAGEHAND_API_URL")
+        self.api_url = self.config.api_url
         self.model_api_key = self.config.model_api_key or os.getenv("MODEL_API_KEY")
         self.model_name = self.config.model_name
 


### PR DESCRIPTION
# why
The default api url always override the one specified in .env

# what changed
fixed init and config to prioritize the .env `STAGEHAND_API_URL`

# test plan
