### PR TITLE
fix: set injected Stagehand cursor position to fixed

### DIFF
--- a/stagehand/domScripts.js
+++ b/stagehand/domScripts.js
@@ -1101,7 +1101,7 @@
             <rect x="12.5" y="13.6" transform="matrix(0.9221 -0.3871 0.3871 0.9221 -5.7605 6.5909)" width="2" height="8" fill="#000000"/>
           </svg>
         `;
-        cursor.style.position = 'absolute';
+        cursor.style.position = 'fixed';
         cursor.style.top = '0';
         cursor.style.left = '0';
         cursor.style.width = '28px';


### PR DESCRIPTION

# why
Previously, the injected Stagehand cursor used `position: absolute`, which caused it to become misaligned when the page was scrolled. Using `position: fixed` ensures the cursor stays anchored to the viewport and always follows the pointer, regardless of scrolling. This directly affects CUA agent execution, where accurate cursor position provides visual grounding and prevents the agent from clicking multiple times due to cursor misalignment.

# what changed
Changed the injected cursor’s CSS from
`cursor.style.position = 'absolute'` to `cursor.style.position = 'fixed';` in domScripts.js.


# test plan
Why
- Verified on a scrollable page that the injected Stagehand cursor remains correctly positioned and follows the pointer during scrolling.