### PR TITLE
Allow to set the slow_mo option when launching local browsers

### DIFF
--- a/stagehand/browser.py
+++ b/stagehand/browser.py
@@ -181,6 +181,7 @@ async def connect_local_browser(
         # Prepare Launch Options (translate keys if needed)
         launch_options = {
             "headless": local_browser_launch_options.get("headless", False),
+            "slow_mo": local_browser_launch_options.get("slow_mo", None),
             "accept_downloads": local_browser_launch_options.get(
                 "acceptDownloads", True
             ),


### PR DESCRIPTION
# why
`slow_mo` is a commonly used Playwright option for local development to easily follow automation actions. See the doc [here](https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-option-slow-mo)

# what changed
When constructing the launch options, we also pass down the slow_mo option if present. Otherwise, the option would be left as `None` which is the default value.

# test plan
Locally tests verify that it works as expected.