### PR TITLE
Adding support for LLM Customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div id="toc" align="center" style="margin-bottom: 0;">
+from litellm.proxy.client.cli.commands.models import models<div id="toc" align="center" style="margin-bottom: 0;">
   <ul style="list-style: none; margin: 0; padding: 0;">
     <a href="https://stagehand.dev">
       <picture>
@@ -158,6 +158,22 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
+```
+
+## LLM Customization
+If you’d like to use a custom LLM, you can do so by providing an `apiKey` and `baseUrl` in the `model_client_options` parameter of the `StagehandConfig`.   
+Most LLMs are OpenAI-compatible, and thus can be used with Stagehand as long as they support structured outputs.  
+Only supported for 'LOCAL' environment.
+
+```python
+config = StagehandConfig(
+    env="LOCAL",
+    model_name="llama3.3",
+    model_client_options={
+        "apiKey": "llama3.3",
+        "baseUrl": "http://localhost:11434/v1"
+    }
+)
 ```
 
 ## Documentation

--- a/stagehand/config.py
+++ b/stagehand/config.py
@@ -19,7 +19,7 @@ class StagehandConfig(BaseModel):
         browserbase_session_create_params (Optional[BrowserbaseSessionCreateParams]): Browserbase session create params.
         browserbase_session_id (Optional[str]): Session ID for resuming Browserbase sessions.
         model_name (Optional[str]): Name of the model to use.
-        model_api_key (Optional[str]): Model API key.
+        model_client_options (Optional[dict[str, Any]]): Options for the model client.
         logger (Optional[Callable[[Any], None]]): Custom logging function.
         verbose (Optional[int]): Verbosity level for logs (1=minimal, 2=medium, 3=detailed).
         use_rich_logging (bool): Whether to use Rich for colorized logging.
@@ -47,8 +47,8 @@ class StagehandConfig(BaseModel):
         alias="apiUrl",
         description="Stagehand API URL",
     )
-    model_api_key: Optional[str] = Field(
-        None, alias="modelApiKey", description="Model API key"
+    model_client_options: Optional[dict[str, Any]] = Field(
+        None, alias="modelClientOptions", description="Configuration options for the language model client (i.e. apiKey, baseURL)",
     )
     verbose: Optional[int] = Field(
         1,

--- a/stagehand/llm/client.py
+++ b/stagehand/llm/client.py
@@ -54,7 +54,7 @@ class LLMClient:
                 setattr(litellm, key, value)
                 self.logger.debug(f"Set global litellm.{key}", category="llm")
             # Handle common aliases or expected config names if necessary
-            elif key == "api_base":  # Example: map api_base if needed
+            elif key == "api_base" or key == "baseURL":  # Example: map api_base if needed
                 litellm.api_base = value
                 self.logger.debug(
                     f"Set global litellm.api_base to {value}", category="llm"

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -68,7 +68,10 @@ class Stagehand:
 
         # Handle non-config parameters
         self.api_url = self.config.api_url
-        self.model_api_key = self.config.model_api_key or os.getenv("MODEL_API_KEY")
+
+        # Handle model-related settings
+        self.model_client_options = self.config.model_client_options or {}
+        self.model_api_key = self.model_client_options.get("apiKey") or os.getenv("MODEL_API_KEY")
         self.model_name = self.config.model_name
 
         # Extract frequently used values from config for convenience
@@ -88,11 +91,6 @@ class Stagehand:
         self.local_browser_launch_options = (
             self.config.local_browser_launch_options or {}
         )
-
-        # Handle model-related settings
-        self.model_client_options = {}
-        if self.model_api_key and "apiKey" not in self.model_client_options:
-            self.model_client_options["apiKey"] = self.model_api_key
 
         # Handle browserbase session create params
         self.browserbase_session_create_params = make_serializable(

--- a/tests/unit/llm/test_llm_integration.py
+++ b/tests/unit/llm/test_llm_integration.py
@@ -40,6 +40,7 @@ class TestLLMClientInitialization:
             api_key="test-key",
             default_model="gpt-4o-mini",
             stagehand_logger=StagehandLogger(),
+            api_base="https://test-api-base.com",
         )
         
         assert client.default_model == "gpt-4o-mini"

--- a/tests/unit/test_client_api.py
+++ b/tests/unit/test_client_api.py
@@ -19,7 +19,7 @@ class TestClientAPI:
             browserbase_session_id="test-session-123",
             api_key="test-api-key",               
             project_id="test-project-id",
-            model_api_key="test-model-api-key",
+            model_client_options={"apiKey": "test-model-api-key"}
         )
         return client
 

--- a/tests/unit/test_client_initialization.py
+++ b/tests/unit/test_client_initialization.py
@@ -23,7 +23,7 @@ class TestClientInitialization:
             browserbase_session_id="test-session",
             api_key="test-api-key",
             project_id="test-project-id",
-            model_api_key="test-model-api-key",
+            model_client_options={"apiKey": "test-model-api-key"},
             verbose=2,
         )
 
@@ -203,3 +203,32 @@ class TestClientInitialization:
         # Call _create_session and expect error
         with pytest.raises(RuntimeError, match="Invalid response format"):
             await client._create_session()
+
+    @mock.patch.dict(os.environ, {"MODEL_API_KEY": "test-model-api-key"}, clear=True)
+    def test_init_with_model_api_key_in_env(self):
+        config = StagehandConfig(env="LOCAL")
+        client = Stagehand(config=config)
+        assert client.model_api_key == "test-model-api-key"
+
+    def test_init_with_custom_llm(self):
+        config = StagehandConfig(
+            env="LOCAL",
+            model_client_options={"apiKey": "custom-llm-key", "baseURL": "https://custom-llm.com"}
+        )
+        client = Stagehand(config=config)
+        assert client.model_api_key == "custom-llm-key"
+        assert client.model_client_options["apiKey"] == "custom-llm-key"
+        assert client.model_client_options["baseURL"] == "https://custom-llm.com"
+
+    def test_init_with_custom_llm_override(self):
+        config = StagehandConfig(
+            env="LOCAL",
+            model_client_options={"apiKey": "custom-llm-key", "baseURL": "https://custom-llm.com"}
+        )
+        client = Stagehand(
+            config=config,
+            model_client_options={"apiKey": "override-llm-key", "baseURL": "https://override-llm.com"}
+        )
+        assert client.model_api_key == "override-llm-key"
+        assert client.model_client_options["apiKey"] == "override-llm-key"
+        assert client.model_client_options["baseURL"] == "https://override-llm.com"


### PR DESCRIPTION
This pull request introduces support for custom language models (LLMs) by replacing the `model_api_key` parameter with a more flexible `model_client_options` parameter. It also updates the documentation, configuration, initialization logic, and tests to reflect this enhancement.

### Core Changes for Custom LLM Support:

* **Configuration Updates:**
  - Replaced `model_api_key` with `model_client_options` in the `StagehandConfig` class, allowing users to specify multiple options such as `apiKey` and `baseUrl` for custom LLMs. (`stagehand/config.py`, [[1]](diffhunk://#diff-99670e70ca17faf4a91952e0d37351dcb749cf2728e0a9b48860fde12710fb9eL22-R22) [[2]](diffhunk://#diff-99670e70ca17faf4a91952e0d37351dcb749cf2728e0a9b48860fde12710fb9eL50-R51)

* **Initialization Logic:**
  - Updated the initialization logic in `stagehand/main.py` to handle `model_client_options` and extract `apiKey` from it, falling back to the `MODEL_API_KEY` environment variable if necessary. (`stagehand/main.py`, [stagehand/main.pyL71-R74](diffhunk://#diff-eecc7283a18349c273fcf7e2073b06c19fe8952208f0d8181f44d522ee348492L71-R74))
  - Removed redundant logic for populating `model_client_options` dynamically. (`stagehand/main.py`, [stagehand/main.pyL92-L96](diffhunk://#diff-eecc7283a18349c273fcf7e2073b06c19fe8952208f0d8181f44d522ee348492L92-L96))

* **LLM Client Enhancements:**
  - Modified `stagehand/llm/client.py` to support `baseURL` in addition to `api_base` for custom LLM configurations. (`stagehand/llm/client.py`, [stagehand/llm/client.pyL57-R57](diffhunk://#diff-fa4a8722a75b68cdc3e7a2a50978337bd72aeb0f1c1867146fdceb51d9344c5aL57-R57))

### Documentation Updates:

* **README.md:**
  - Added a new section on LLM customization, including an example of how to configure `StagehandConfig` with `model_client_options` for a custom LLM. (`README.md`, [README.mdR163-R178](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R163-R178))

### Test Coverage:

* **Unit Tests:**
  - Updated existing tests to replace `model_api_key` with `model_client_options`. (`tests/unit/llm/test_llm_integration.py`, [[1]](diffhunk://#diff-6cd01dce2a36f73ca5fd49dcea39e5cd54867cb4e399bec1831ef0e36cadddcaR43); `tests/unit/test_client_api.py`, [[2]](diffhunk://#diff-91008b1079c7aa373120fe0316744e3a781979a6c655756fc92507647368815bL22-R22); `tests/unit/test_client_initialization.py`, [[3]](diffhunk://#diff-e1fd88f636fc37673345f6c5d958d0f1819ddf2aac6209958e7045ea33c800feL26-R26)
  - Added new tests to validate custom LLM configurations, including overrides and environment variable fallbacks. (`tests/unit/test_client_initialization.py`, [tests/unit/test_client_initialization.pyR206-R234](diffhunk://#diff-e1fd88f636fc37673345f6c5d958d0f1819ddf2aac6209958e7045ea33c800feR206-R234))