### PR TITLE
fix api key example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ async def main():
         api_key=os.getenv("BROWSERBASE_API_KEY"),
         project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
         model_name="google/gemini-2.5-flash-preview-05-20",
-        model_client_options={"apiKey": os.getenv("MODEL_API_KEY")},
+        model_api_key=os.getenv("MODEL_API_KEY"),
     )
     
     stagehand = Stagehand(config)


### PR DESCRIPTION



# why
config `model_client_options` is not in config.py, this configuration not working

https://github.com/browserbase/stagehand-python/blob/main/stagehand/config.py#L22

# what changed

change this config to model_api_key

# test plan
