### PR TITLE
add headers to cdp connect

### DIFF
--- a/stagehand/browser.py
+++ b/stagehand/browser.py
@@ -130,8 +130,7 @@ async def connect_local_browser(
         logger.info(f"Connecting to local browser via CDP URL: {cdp_url}")
         try:
             browser = await playwright.chromium.connect_over_cdp(
-                cdp_url, 
-                headers=local_browser_launch_options.get("headers")
+                cdp_url, headers=local_browser_launch_options.get("headers")
             )
 
             if not browser.contexts:


### PR DESCRIPTION
# why
We have some headers we need to pass in for authentication to connect via CDP. 

# what changed
Added a headers field to the `local_browser_launch_options`
# test plan
