### PR TITLE
Add better handling for native dropdowns

### DIFF
--- a/stagehand/handlers/act_handler_utils.py
+++ b/stagehand/handlers/act_handler_utils.py
@@ -339,6 +339,27 @@ async def press_key(ctx: MethodHandlerContext) -> None:
         raise e
 
 
+async def select_option(ctx: MethodHandlerContext) -> None:
+    try:
+        text = str(ctx.args[0]) if ctx.args and ctx.args[0] is not None else ""
+        await ctx.locator.select_option(text, timeout=5_000)
+    except Exception as e:
+        ctx.logger.error(
+            message="error selecting option",
+            category="action",
+            auxiliary={
+                "error": {"value": str(e), "type": "string"},
+                "trace": {
+                    "value": getattr(e, "__traceback__", ""),
+                    "type": "string",
+                },
+                "xpath": {"value": ctx.xpath, "type": "string"},
+                "args": {"value": json.dumps(ctx.args), "type": "object"},
+            },
+        )
+        raise e
+
+
 async def click_element(ctx: MethodHandlerContext) -> None:
     ctx.logger.debug(
         message=f"page URL before click {ctx.stagehand_page._page.url}",
@@ -500,4 +521,5 @@ method_handler_map: dict[
     "click": click_element,
     "nextChunk": scroll_to_next_chunk,
     "prevChunk": scroll_to_previous_chunk,
+    "selectOptionFromDropdown": select_option,
 }

--- a/stagehand/llm/prompts.py
+++ b/stagehand/llm/prompts.py
@@ -200,7 +200,9 @@ If the action is completely unrelated to a potential action to be taken on the p
 ONLY return one action. If multiple actions are relevant, return the most relevant one.
 If the user is asking to scroll to a position on the page, e.g., 'halfway' or 0.75, etc, you must return the argument formatted as the correct percentage, e.g., '50%' or '75%', etc.
 If the user is asking to scroll to the next chunk/previous chunk, choose the nextChunk/prevChunk method. No arguments are required here.
-If the action implies a key press, e.g., 'press enter', 'press a', 'press space', etc., always choose the press method with the appropriate key as argument — e.g. 'a', 'Enter', 'Space'. Do not choose a click action on an on-screen keyboard. Capitalize the first character like 'Enter', 'Tab', 'Escape' only for special keys."""
+If the action implies a key press, e.g., 'press enter', 'press a', 'press space', etc., always choose the press method with the appropriate key as argument — e.g. 'a', 'Enter', 'Space'. Do not choose a click action on an on-screen keyboard. Capitalize the first character like 'Enter', 'Tab', 'Escape' only for special keys.
+If the action implies choosing an option from a dropdown, AND the corresponding element is a 'select' element, choose the selectOptionFromDropdown method. The argument should be the text of the option to select.
+If the action implies choosing an option from a dropdown, and the corresponding element is NOT a 'select' element, choose the click method."""
 
     if variables and len(variables) > 0:
         variables_prompt = f"The following variables are available to use in the action: {', '.join(variables.keys())}. Fill the argument variables with the variable name."

--- a/tests/e2e/test_act_integration.py
+++ b/tests/e2e/test_act_integration.py
@@ -111,6 +111,92 @@ class TestActIntegration:
 
     @pytest.mark.asyncio
     @pytest.mark.local
+    async def test_selecting_option_local(self, local_stagehand):
+        """Test option selecting capability in LOCAL mode"""
+        stagehand = local_stagehand
+        
+        # Navigate to a page with a form containing a dropdown
+        await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/nested-dropdown/")
+        
+        # Select an option from the dropdown.
+        await stagehand.page.act("Choose 'Smog Check Technician' from the 'License Type' dropdown")
+        
+        # Verify the selected option.
+        selected_option = await stagehand.page.locator(
+            "xpath=/html/body/form/div[1]/div[3]/article/div[2]/div[1]/select[2] >> option:checked"
+        ).text_content()
+
+        assert selected_option == "Smog Check Technician"
+
+    @pytest.mark.asyncio
+    @pytest.mark.browserbase
+    @pytest.mark.skipif(
+        not (os.getenv("BROWSERBASE_API_KEY") and os.getenv("BROWSERBASE_PROJECT_ID")),
+        reason="Browserbase credentials not available"
+    )
+    async def test_selecting_option_browserbase(self, browserbase_stagehand):
+        """Test option selecting capability in BROWSERBASE mode"""
+        stagehand = browserbase_stagehand
+        
+        # Navigate to a page with a form containing a dropdown
+        await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/nested-dropdown/")
+        
+        # Select an option from the dropdown.
+        await stagehand.page.act("Choose 'Smog Check Technician' from the 'License Type' dropdown")
+        
+        # Verify the selected option.
+        selected_option = await stagehand.page.locator(
+            "xpath=/html/body/form/div[1]/div[3]/article/div[2]/div[1]/select[2] >> option:checked"
+        ).text_content()
+
+        assert selected_option == "Smog Check Technician"
+
+    @pytest.mark.asyncio
+    @pytest.mark.local
+    async def test_selecting_option_custom_input_local(self, local_stagehand):
+        """Test not selecting option on custom select input in LOCAL mode"""
+        stagehand = local_stagehand
+        
+        # Navigate to a page with a form containing a dropdown
+        await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/expand-dropdown/")
+        
+        # Select an option from the dropdown.
+        await stagehand.page.act("Click the 'Select a Country' dropdown")
+
+        # Wait for dropdown to expand
+        await asyncio.sleep(1)
+        
+        # We are expecting stagehand to click the dropdown to expand it, and therefore
+        # the available options should now be contained in the full a11y tree.
+
+        # To test, we'll grab the full a11y tree, and make sure it contains 'Green'
+        extraction = await stagehand.page.extract()
+        assert "Canada" in extraction.data
+
+    @pytest.mark.asyncio
+    @pytest.mark.local
+    async def test_selecting_option_hidden_input_local(self, local_stagehand):
+        """Test not selecting option on hidden input in LOCAL mode"""
+        stagehand = local_stagehand
+        
+        # Navigate to a page with a form containing a dropdown
+        await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/hidden-input-dropdown/")
+        
+        # Select an option from the dropdown.
+        await stagehand.page.act("Click to expand the 'Favourite Colour' dropdown")
+        
+        # Wait for dropdown to expand
+        await asyncio.sleep(1)
+        
+        # We are expecting stagehand to click the dropdown to expand it, and therefore
+        # the available options should now be contained in the full a11y tree.
+
+        # To test, we'll grab the full a11y tree, and make sure it contains 'Green'
+        extraction = await stagehand.page.extract()
+        assert "Green" in extraction.data
+
+    @pytest.mark.asyncio
+    @pytest.mark.local
     async def test_button_clicking_local(self, local_stagehand):
         """Test button clicking functionality in LOCAL mode"""
         stagehand = local_stagehand

--- a/tests/e2e/test_act_integration.py
+++ b/tests/e2e/test_act_integration.py
@@ -169,7 +169,7 @@ class TestActIntegration:
         # We are expecting stagehand to click the dropdown to expand it, and therefore
         # the available options should now be contained in the full a11y tree.
 
-        # To test, we'll grab the full a11y tree, and make sure it contains 'Green'
+        # To test, we'll grab the full a11y tree, and make sure it contains 'Canada'
         extraction = await stagehand.page.extract()
         assert "Canada" in extraction.data
 


### PR DESCRIPTION
This PR adds better handling for native dropdowns. This feature was recently introduced in the JS repo: https://github.com/browserbase/stagehand/pull/842 so this change is a simple port to python.

This should resolve this issue: https://github.com/browserbase/stagehand-python/issues/135

# Why

Currently native os-level dropdowns are not able to be acted on. My understanding is these UI elements are rendered by the OS and are not part of the DOM which makes them invisible to playwright.

# What changed

A straight port of the JS PR: https://github.com/browserbase/stagehand/pull/842

TL;DR: Add a new method `selectOptionFromDropdown` and instructions in the prompt for how to use it. The method uses Playwright's `select_option` locator method.

There is one exception: I didn't overwrite elements with `combobox` role to `select` role in the `_clean_structural_nodes` as is in the JS PR. This function has a slightly different implementation than it's JS counterpart and so I didn't want to mess with it especially because the JS PR didn't include a test case for it. Let me know if you want me to add this for the sake of staying consistent with the other repo.


# Test plan

I ported over the test cases from the JS PR:
1. Function is used properly on native dropdowns (LOCAL + BROWSERBASE)
2. Function is skipped properly on hidden and custom dropdowns (LOCAL)
