### PR TITLE
add headers to cdp connect (#136)

### DIFF
--- a/stagehand/browser.py
+++ b/stagehand/browser.py
@@ -129,7 +129,9 @@ async def connect_local_browser(
     if cdp_url:
         logger.info(f"Connecting to local browser via CDP URL: {cdp_url}")
         try:
-            browser = await playwright.chromium.connect_over_cdp(cdp_url)
+            browser = await playwright.chromium.connect_over_cdp(
+                cdp_url, headers=local_browser_launch_options.get("headers")
+            )
 
             if not browser.contexts:
                 raise RuntimeError(f"No browser contexts found at CDP URL: {cdp_url}")


### PR DESCRIPTION
# why
To unblock certain local configurations

# what changed
added optional headers to be passed on cdp_url if local_browser_launch_options includes the 'headers' key

# test plan
