### PR TITLE
pass sdk version number to api for debug

### DIFF
--- a/.changeset/belligerent-gharial-of-attack.md
+++ b/.changeset/belligerent-gharial-of-attack.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+Pass sdk version number to API for debugging

--- a/stagehand/api.py
+++ b/stagehand/api.py
@@ -68,7 +68,8 @@ async def _create_session(self):
         try:
             result = version(package_str)
         except PackageNotFoundError:
-            result = package_str + " not installed"
+            self.logger.error(package_str + " not installed")
+            result = None
         return result
 
     headers = {

--- a/stagehand/api.py
+++ b/stagehand/api.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from importlib.metadata import version as get_version
+from importlib.metadata import version
 from typing import Any
 
 from .utils import convert_dict_keys_to_camel_case
@@ -63,6 +63,13 @@ async def _create_session(self):
 
     if hasattr(self, "model_client_options") and self.model_client_options:
         payload["modelClientOptions"] = self.model_client_options
+
+    def get_version(package_str):
+        try:
+            result = version(package_str)
+        except PackageNotFoundError:
+            result = package_str + " not installed"
+        return result
 
     headers = {
         "x-bb-api-key": self.browserbase_api_key,

--- a/stagehand/api.py
+++ b/stagehand/api.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 from .utils import convert_dict_keys_to_camel_case

--- a/stagehand/api.py
+++ b/stagehand/api.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from importlib.metadata import version
+from importlib.metadata import version, PackageNotFoundError
 from typing import Any
 
 from .utils import convert_dict_keys_to_camel_case

--- a/stagehand/api.py
+++ b/stagehand/api.py
@@ -1,5 +1,6 @@
 import json
 from datetime import datetime
+from importlib.metadata import version as get_version
 from typing import Any
 
 from .utils import convert_dict_keys_to_camel_case
@@ -70,6 +71,7 @@ async def _create_session(self):
         "Content-Type": "application/json",
         "x-sent-at": datetime.now().isoformat(),
         "x-language": "python",
+        "x-sdk-version": get_version("stagehand"),
     }
 
     # async with self._client:


### PR DESCRIPTION
# why
To help debug sessions faster and to respect backwards version compatibility long term


# what changed

# test plan
