### PR TITLE
add timeout to async playwright

### DIFF
--- a/.changeset/wakeful-pogona-of-stamina.md
+++ b/.changeset/wakeful-pogona-of-stamina.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+simple event loop timeout for strict event loops for async playwright (which has blocking start)

--- a/.changeset/wealthy-lion-of-honeydew.md
+++ b/.changeset/wealthy-lion-of-honeydew.md
@@ -1,5 +1,0 @@
----
-"stagehand": patch
----
-
-moved async playwright start to a thread to prevent blocking behaviour

--- a/.changeset/wealthy-lion-of-honeydew.md
+++ b/.changeset/wealthy-lion-of-honeydew.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+moved async playwright start to a thread to prevent blocking behaviour

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -453,7 +453,9 @@ class Stagehand:
 
         self._initialized = True
 
-    async def _connect_local_browser_threaded(self, playwright, launch_options, stagehand, logger):
+    async def _connect_local_browser_threaded(
+        self, playwright, launch_options, stagehand, logger
+    ):
         """Connect to local browser using the threaded Playwright instance."""
         return await self._playwright_runner.run_coroutine_async(
             connect_local_browser(playwright, launch_options, stagehand, logger)

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -392,7 +392,7 @@ class Stagehand:
         self.logger.debug(f"Environment: {self.env}")
 
         # Always initialize playwright with timeout to avoid hanging
-        # This ensures compatibility with strict event loop environments like Langgraph
+        # This ensures compatibility with strict event loop environments
         self._playwright = await self._init_playwright_with_timeout()
 
         if self.env == "BROWSERBASE":
@@ -457,7 +457,7 @@ class Stagehand:
         Initialize playwright with a timeout to avoid hanging in strict event loop environments.
         
         This method adds a timeout to the regular async_playwright().start() to prevent
-        hanging in environments like Langgraph that restrict blocking operations.
+        hanging in environments that restrict blocking operations.
         """
         self.logger.debug("Starting playwright initialization with timeout...")
         
@@ -476,8 +476,7 @@ class Stagehand:
             self.logger.error("Playwright initialization timed out")
             raise RuntimeError(
                 "Playwright initialization timed out after 30 seconds. This may indicate "
-                "your environment has strict event loop restrictions. If using Langgraph, "
-                "consider using the --allow-blocking flag."
+                "your environment has strict event loop restrictions."
             )
         except Exception as e:
             self.logger.error(f"Failed to initialize playwright: {e}")

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -455,23 +455,22 @@ class Stagehand:
     async def _init_playwright_with_timeout(self):
         """
         Initialize playwright with a timeout to avoid hanging in strict event loop environments.
-        
+
         This method adds a timeout to the regular async_playwright().start() to prevent
         hanging in environments that restrict blocking operations.
         """
         self.logger.debug("Starting playwright initialization with timeout...")
-        
+
         try:
             # Use asyncio.wait_for to add a timeout to prevent hanging
             # If the environment doesn't allow blocking operations, this will fail fast
             playwright_instance = await asyncio.wait_for(
-                async_playwright().start(),
-                timeout=30.0  # 30 second timeout
+                async_playwright().start(), timeout=30.0  # 30 second timeout
             )
-            
+
             self.logger.debug("Playwright initialized successfully")
             return playwright_instance
-            
+
         except asyncio.TimeoutError:
             self.logger.error("Playwright initialization timed out")
             raise RuntimeError(

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -476,7 +476,7 @@ class Stagehand:
             raise RuntimeError(
                 "Playwright initialization timed out after 30 seconds. This may indicate "
                 "your environment has strict event loop restrictions."
-            )
+            ) from None
         except Exception as e:
             self.logger.error(f"Failed to initialize playwright: {e}")
             raise RuntimeError(

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -453,14 +453,6 @@ class Stagehand:
 
         self._initialized = True
 
-    async def _connect_local_browser_threaded(
-        self, playwright, launch_options, stagehand, logger
-    ):
-        """Connect to local browser using the threaded Playwright instance."""
-        return await self._playwright_runner.run_coroutine_async(
-            connect_local_browser(playwright, launch_options, stagehand, logger)
-        )
-
     def agent(self, **kwargs) -> Agent:
         """
         Create an agent instance configured with the provided options.


### PR DESCRIPTION
# why
Strict event loop envs break due to blocking behavior inside async playwright start.

# what changed

# test plan
