### PR TITLE
Fix error in press_key act util function

### DIFF
--- a/stagehand/handlers/act_handler_utils.py
+++ b/stagehand/handlers/act_handler_utils.py
@@ -307,7 +307,7 @@ async def fill_or_type(ctx: MethodHandlerContext) -> None:
 async def press_key(ctx: MethodHandlerContext) -> None:
     try:
         key = str(ctx.args[0]) if ctx.args and ctx.args[0] is not None else ""
-        await ctx.locator._page.keyboard.press(key)
+        await ctx.locator.press(key)
         await handle_possible_page_navigation(
             "press",
             ctx.xpath,
@@ -398,7 +398,7 @@ async def fallback_locator_method(ctx: MethodHandlerContext) -> None:
     ctx.logger.debug(
         message="page URL before action",
         category="action",
-        auxiliary={"url": {"value": ctx.locator._page.url, "type": "string"}},
+        auxiliary={"url": {"value": ctx.stagehand_page._page.url, "type": "string"}},
     )
     try:
         method_to_call = getattr(ctx.locator, ctx.method)

--- a/stagehand/handlers/act_handler_utils.py
+++ b/stagehand/handlers/act_handler_utils.py
@@ -307,7 +307,7 @@ async def fill_or_type(ctx: MethodHandlerContext) -> None:
 async def press_key(ctx: MethodHandlerContext) -> None:
     try:
         key = str(ctx.args[0]) if ctx.args and ctx.args[0] is not None else ""
-        await ctx.locator.press(key)
+        await ctx.stagehand_page._page.keyboard.press(key)
         await handle_possible_page_navigation(
             "press",
             ctx.xpath,


### PR DESCRIPTION
# Purpose

Resolves this issue:
https://github.com/browserbase/stagehand-python/issues/154

# Approach

Use the proper `Locator.press` method to in the `press_key` util function.

# Tests

The existing `test_keyboard_actions_local` touches this and now works without any errors.

# Other

I fixed the log lower down that would throw the same exception.
