### PR TITLE
feat: port new page handling from JS Stagehand PR #844

### DIFF
--- a/stagehand/browser.py
+++ b/stagehand/browser.py
@@ -237,16 +237,18 @@ async def connect_local_browser(
 
     # Apply stealth scripts
     await apply_stealth_scripts(context, logger)
+    
+    # Initialize StagehandContext
+    stagehand_context = await StagehandContext.init(context, stagehand_instance)
 
     # Get the initial page (usually one is created by default)
     if context.pages:
         playwright_page = context.pages[0]
         logger.debug("Using initial page from local context.")
+        page = await stagehand_context.get_stagehand_page(playwright_page)
     else:
         logger.debug("No initial page found, creating a new one.")
-        playwright_page = await context.new_page()
-
-    page = StagehandPage(playwright_page, stagehand_instance)
+        page = await stagehand_context.new_page()
 
     return browser, context, stagehand_context, page, temp_user_data_dir
 

--- a/stagehand/context.py
+++ b/stagehand/context.py
@@ -40,7 +40,10 @@ class StagehandContext:
     async def get_stagehand_page(self, pw_page: Page) -> StagehandPage:
         if pw_page not in self.page_map:
             return await self.create_stagehand_page(pw_page)
-        return self.page_map[pw_page]
+        stagehand_page = self.page_map[pw_page]
+        # Update active page when getting a page
+        self.set_active_page(stagehand_page)
+        return stagehand_page
 
     async def get_stagehand_pages(self) -> list:
         # Return a list of StagehandPage wrappers for all pages in the context
@@ -53,24 +56,96 @@ class StagehandContext:
 
     def set_active_page(self, stagehand_page: StagehandPage):
         self.active_stagehand_page = stagehand_page
-        # Optionally update the active page in the stagehand client if needed
+        # Update the active page in the stagehand client
         if hasattr(self.stagehand, "_set_active_page"):
             self.stagehand._set_active_page(stagehand_page)
+            self.stagehand.logger.debug(
+                f"Set active page to: {stagehand_page.url}",
+                category="context"
+            )
+        else:
+            self.stagehand.logger.debug(
+                "Stagehand does not have _set_active_page method",
+                category="context"
+            )
 
     def get_active_page(self) -> StagehandPage:
         return self.active_stagehand_page
 
     @classmethod
     async def init(cls, context: BrowserContext, stagehand):
+        stagehand.logger.debug("StagehandContext.init() called", category="context")
         instance = cls(context, stagehand)
         # Pre-initialize StagehandPages for any existing pages
+        stagehand.logger.debug(f"Found {len(instance._context.pages)} existing pages", category="context")
         for pw_page in instance._context.pages:
             await instance.create_stagehand_page(pw_page)
         if instance._context.pages:
             first_page = instance._context.pages[0]
             stagehand_page = await instance.get_stagehand_page(first_page)
             instance.set_active_page(stagehand_page)
+        
+        # Add event listener for new pages (popups, new tabs from window.open, etc.)
+        def handle_page_event(pw_page):
+            instance.stagehand.logger.debug(
+                f"Page event fired for URL: {pw_page.url}",
+                category="context"
+            )
+            instance._handle_new_page(pw_page)
+        
+        instance.stagehand.logger.debug(
+            f"Setting up page event listener on context (ID: {id(context)})",
+            category="context"
+        )
+        context.on("page", handle_page_event)
+        instance.stagehand.logger.debug(
+            "Page event listener setup complete",
+            category="context"
+        )
+        
         return instance
+    
+    def _handle_new_page(self, pw_page: Page):
+        """
+        Handle new pages created by the browser (popups, window.open, etc.).
+        This runs synchronously in the event handler context.
+        """
+        async def _async_handle():
+            try:
+                self.stagehand.logger.debug(
+                    f"Creating StagehandPage for new page with URL: {pw_page.url}",
+                    category="context"
+                )
+                stagehand_page = await self.create_stagehand_page(pw_page)
+                self.set_active_page(stagehand_page)
+                self.stagehand.logger.log(
+                    "New page detected and initialized",
+                    level=2,
+                    category="context",
+                    auxiliary={"url": {"value": pw_page.url, "type": "string"}}
+                )
+            except Exception as e:
+                self.stagehand.logger.error(
+                    f"Failed to initialize new page: {str(e)}",
+                    category="context"
+                )
+                import traceback
+                self.stagehand.logger.error(
+                    f"Traceback: {traceback.format_exc()}",
+                    category="context"
+                )
+        
+        # Schedule the async work
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_async_handle())
+        except RuntimeError:
+            # No event loop running, which shouldn't happen in normal operation
+            self.stagehand.logger.error(
+                "No event loop available to handle new page",
+                category="context"
+            )
 
     def __getattr__(self, name):
         # Forward attribute lookups to the underlying BrowserContext

--- a/stagehand/handlers/act_handler_utils.py
+++ b/stagehand/handlers/act_handler_utils.py
@@ -471,10 +471,8 @@ async def handle_possible_page_navigation(
             category="action",
             auxiliary={"url": {"value": new_opened_tab.url, "type": "string"}},
         )
-        new_tab_url = new_opened_tab.url
-        await new_opened_tab.close()
-        await stagehand_page._page.goto(new_tab_url)
-        await stagehand_page._page.wait_for_load_state("domcontentloaded")
+        # Don't close the new tab - let it remain open and be handled by the context
+        # The StagehandContext will automatically make this the active page via its event listener
 
     try:
         await stagehand_page._wait_for_settled_dom(dom_settle_timeout_ms)

--- a/stagehand/handlers/cua_handler.py
+++ b/stagehand/handlers/cua_handler.py
@@ -559,21 +559,21 @@ class CUAHandler:  # Computer Use Agent Handler
                 pass  # The action that might open a page has already run. We check if one was caught.
             newly_opened_page = await new_page_info.value
 
-            new_page_url = newly_opened_page.url
-            await newly_opened_page.close()
-            await self.page.goto(new_page_url, timeout=dom_settle_timeout_ms)
-            # After navigating, the DOM needs to settle on the new URL.
-            await self._wait_for_settled_dom(timeout_ms=dom_settle_timeout_ms)
+            # Don't close the new tab - let it remain open and be handled by the context
+            # The StagehandContext will automatically make this the active page via its event listener
+            self.logger.debug(
+                f"New page detected with URL: {newly_opened_page.url}",
+                category=StagehandFunctionName.AGENT,
+            )
 
         except asyncio.TimeoutError:
             newly_opened_page = None
         except Exception:
             newly_opened_page = None
 
-        # If no new tab was opened and handled by navigating, or if we are on the original page after handling a new tab,
-        # then proceed to wait for DOM settlement on the current page.
-        if not newly_opened_page:
-            await self._wait_for_settled_dom(timeout_ms=dom_settle_timeout_ms)
+        # Always wait for DOM settlement on the current page
+        # If a new tab was opened, it will be handled separately by the context
+        await self._wait_for_settled_dom(timeout_ms=dom_settle_timeout_ms)
 
         final_url = self.page.url
         if final_url != initial_url:


### PR DESCRIPTION
- Add live page proxy that dynamically tracks the focused page
- Implement context event listener to initialize new pages automatically
- Remove automatic tab closing behavior in act_handler_utils and cua_handler
- Keep both original and new tabs open when new pages are created
- Ensure stagehand.page always references the current active page

This implementation matches the behavior of browserbase/stagehand#844

# why

# what changed

# test plan
