### PR TITLE
Fix CDP connection headers parameter name

### DIFF
--- a/stagehand/browser.py
+++ b/stagehand/browser.py
@@ -130,7 +130,7 @@ async def connect_local_browser(
         logger.info(f"Connecting to local browser via CDP URL: {cdp_url}")
         try:
             browser = await playwright.chromium.connect_over_cdp(
-                cdp_url, headers=local_browser_launch_options.get("headers")
+                cdp_url, headers=local_browser_launch_options.get("extra_http_headers")
             )
 
             if not browser.contexts:


### PR DESCRIPTION
Changed from 'headers' to 'extra_http_headers' to match Playwright's expected parameter name for connect_over_cdp.

🤖 Generated with [Claude Code](https://claude.ai/code)

# why

# what changed

# test plan
