### PR TITLE
Enable access to iframes on api

### DIFF
--- a/.changeset/ambrosial-anaconda-of-blizzard.md
+++ b/.changeset/ambrosial-anaconda-of-blizzard.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+Enable access to iframes on api

--- a/stagehand/page.py
+++ b/stagehand/page.py
@@ -137,9 +137,14 @@ class StagehandPage:
         elif isinstance(action_or_result, ActOptions):
             payload = action_or_result.model_dump(exclude_none=True, by_alias=True)
         elif isinstance(action_or_result, dict):
-            payload = ObserveResult(**action_or_result).model_dump(
-                exclude_none=True, by_alias=True
-            )
+            if "description" in action_or_result:
+                payload = ObserveResult(**action_or_result).model_dump(
+                    exclude_none=True, by_alias=True
+                )
+            else:
+                payload = ActOptions(**action_or_result).model_dump(
+                    exclude_none=True, by_alias=True
+                )
         else:
             raise TypeError(
                 "Invalid arguments for 'act'. Expected str, ObserveResult, or ActOptions."
@@ -156,6 +161,10 @@ class StagehandPage:
                     self, self._stagehand, "", self._stagehand.self_heal
                 )
             self._stagehand.logger.debug("act", category="act", auxiliary=payload)
+            if payload.get("iframes"):
+                raise ValueError(
+                    "iframes is not yet supported without API (to enable make sure you set env=BROWSERBASE and use_api=true)"
+                )
             result = await self._act_handler.act(payload)
             return result
 

--- a/stagehand/schemas.py
+++ b/stagehand/schemas.py
@@ -53,6 +53,7 @@ class ActOptions(StagehandBaseModel):
     dom_settle_timeout_ms: Optional[int] = None
     timeout_ms: Optional[int] = None
     model_client_options: Optional[dict[str, Any]] = None
+    iframes: Optional[bool] = None
 
 
 class ActResult(StagehandBaseModel):
@@ -98,6 +99,7 @@ class ExtractOptions(StagehandBaseModel):
     use_text_extract: Optional[bool] = None
     dom_settle_timeout_ms: Optional[int] = None
     model_client_options: Optional[dict[Any, Any]] = None
+    iframes: Optional[bool] = None
 
     @field_serializer("schema_definition")
     def serialize_schema_definition(
@@ -196,6 +198,7 @@ class ObserveOptions(StagehandBaseModel):
     draw_overlay: Optional[bool] = None
     dom_settle_timeout_ms: Optional[int] = None
     model_client_options: Optional[dict[str, Any]] = None
+    iframes: Optional[bool] = None
 
 
 class ObserveResult(StagehandBaseModel):


### PR DESCRIPTION
# why
The new version of Stagehand API supports iframes, but the python sdk doesn't directly support them

# what changed
Enabled access to setting `iframes:True` whenever the environment is "BROWSERBASE" (with api enabled)

# test plan
