### PR TITLE
Patch issue with passing a created session_id to init on api mode

### DIFF
--- a/.changeset/warping-colorful-shellfish.md
+++ b/.changeset/warping-colorful-shellfish.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+Patch issue with passing a created session_id to init on api mode

--- a/stagehand/api.py
+++ b/stagehand/api.py
@@ -30,6 +30,7 @@ async def _create_session(self):
         "modelName": self.model_name,
         "verbose": 2 if self.verbose == 3 else self.verbose,
         "domSettleTimeoutMs": self.dom_settle_timeout_ms,
+        "browserbaseSessionID": self.session_id,
         "browserbaseSessionCreateParams": (
             browserbase_session_create_params
             if browserbase_session_create_params

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -399,15 +399,7 @@ class Stagehand:
         if self.env == "BROWSERBASE":
             # Create session if we don't have one
             if self.use_api:
-                if not self.session_id:
-                    await self._create_session()  # Uses self._client and api_url
-                    self.logger.debug(
-                        f"Created new Browserbase session via Stagehand server: {self.session_id}"
-                    )
-                else:
-                    self.logger.debug(
-                        f"Using existing Browserbase session: {self.session_id}"
-                    )
+                await self._create_session()  # Uses self._client and api_url
 
             # Connect to remote browser
             try:


### PR DESCRIPTION
# why
Session id is not serialized properly when reconnecting to a session

# what changed
Made sure `init()` calls `_createSession()` when passing an existing session_id

# test plan
