### PR TITLE
Fix temp setting for GPT-5

### DIFF
--- a/.changeset/towering-organic-grouse.md
+++ b/.changeset/towering-organic-grouse.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+Fix temperature setting for GPT-5 family of models

--- a/stagehand/llm/client.py
+++ b/stagehand/llm/client.py
@@ -114,7 +114,6 @@ class LLMClient:
         if "gpt-5" in completion_model:
             filtered_params["temperature"] = 1
 
-
         self.logger.debug(
             f"Calling litellm.completion with model={completion_model} and params: {filtered_params}",
             category="llm",

--- a/stagehand/llm/client.py
+++ b/stagehand/llm/client.py
@@ -110,6 +110,10 @@ class LLMClient:
         filtered_params = {
             k: v for k, v in params.items() if v is not None or k in kwargs
         }
+        # Fixes parameters for GPT-5 family of models
+        if "gpt-5" in completion_model:
+            filtered_params["temperature"] = 1
+
 
         self.logger.debug(
             f"Calling litellm.completion with model={completion_model} and params: {filtered_params}",


### PR DESCRIPTION
# why
OpenAI decided to change their inference configuration

# what changed
New GPT-5 family models don't accept temperature as an option, set `temperature:1` for this family of models

# test plan
