### PR TITLE
Debug/init

### DIFF
--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -159,7 +159,7 @@ class Stagehand:
             self.config = config
 
         # Handle non-config parameters
-        self.api_url = self.config.api_url or os.getenv("STAGEHAND_API_URL")
+        self.api_url = self.config.api_url
         if not self.api_url:
             raise ValueError(
                 "api_url is not set. Please set StagehandConfig.api_url "

--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -159,7 +159,18 @@ class Stagehand:
             self.config = config
 
         # Handle non-config parameters
-        self.api_url = self.config.api_url
+        self.api_url = self.config.api_url or os.getenv("STAGEHAND_API_URL")
+        if not self.api_url:
+            raise ValueError(
+                "api_url is not set. Please set StagehandConfig.api_url "
+                "or the STAGEHAND_API_URL environment variable."
+            )
+
+        if not self.api_url.startswith(("http://", "https://")):
+            raise ValueError(
+                f"Invalid api_url: {self.api_url}. Must start with http:// or https://"
+            )
+
         self.model_api_key = self.config.model_api_key or os.getenv("MODEL_API_KEY")
         self.model_name = self.config.model_name
 


### PR DESCRIPTION
# why
Following the [quickstart](https://docs.stagehand.dev/get_started/quickstart#python), calling `await stagehand.init()` can fail with:
UnsupportedProtocol: Request URL is missing an 'http://' or 'https://' protocol.
This happens when `api_url` is unset or set without a scheme (e.g., `"api.stagehand.browserbase.com/v1"`).

# what changed
- Validate `api_url` in `Stagehand.__init__`  
- If empty → raise:
    ```
    ValueError: api_url is not set. Please set StagehandConfig.api_url or the STAGEHAND_API_URL environment variable.
    ```
  - If it doesn’t start with `http://` or `https://` → raise:
    ```
    ValueError: Invalid api_url: <value>. Must start with http:// or https://
    ```
- Keep existing behavior for valid configs; this just fails earlier
Relation to #116

Related: #116 . This PR is similar to #116 by catching misconfigurations (missing scheme / empty) before reaching httpx,