### PR TITLE
Fix max_steps parsing for agent execute

### DIFF
--- a/.changeset/dragon-of-fabulous-persistence.md
+++ b/.changeset/dragon-of-fabulous-persistence.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+Fix max_steps parsing for agent execute options

--- a/stagehand/agent/agent.py
+++ b/stagehand/agent/agent.py
@@ -132,7 +132,7 @@ class Agent:
             try:
                 agent_result = await self.client.run_task(
                     instruction=instruction,
-                    max_steps=self.config.max_steps,
+                    max_steps=options.max_steps or self.config.max_steps,
                     options=options,
                 )
             except Exception as e:


### PR DESCRIPTION
# why
`max_steps` was being overriden by `config.max_steps`. This caused the values passed on `execute` to be disregarded, and the values (or default value) in the `agent` constructor to be the predominant one. 

# what changed
Updated the execute function to take the parameter `max_steps` from its arguments and only fall back to the config if value is `None`

# test plan
