### PR TITLE
Draft: Fixing downloads behavior for env=LOCAL setup

### DIFF
--- a/stagehand/main.py
+++ b/stagehand/main.py
@@ -531,6 +531,30 @@ class Stagehand:
                     self.logger,
                 )
                 self._playwright_page = self._page._page
+
+                # Set up download behavior via CDP
+                try:
+                    # Check if downloadsPath is provided in launch options, otherwise use default
+                    downloads_path = self.local_browser_launch_options.get("downloadsPath")
+                    if not downloads_path:
+                        downloads_path = str(Path.cwd() / "downloads")
+                        # Create downloads directory if it doesn't exist
+                        Path(downloads_path).mkdir(parents=True, exist_ok=True)
+
+                    # Create CDP session for the page
+                    cdp_session = await self._context.new_cdp_session(self._playwright_page)
+                    # Enable download behavior
+                    await cdp_session.send("Browser.setDownloadBehavior", {
+                        "behavior": "allow",
+                        "downloadPath": downloads_path,
+                        "eventsEnabled": True
+                    })
+
+                    self.logger.debug(f"Set up CDP download behavior for local browser with path: {downloads_path}")
+                except Exception as e:
+                    self.logger.warning(f"Failed to set up CDP download behavior for local browser: {str(e)}")
+                    # Continue without download support - non-critical feature
+
             except Exception:
                 await self.close()
                 raise


### PR DESCRIPTION
# why

  Downloads were not working properly in LOCAL mode when using Playwright with CDP (Chrome DevTools Protocol). The browser's default download behavior was not configured, causing downloads to fail or be blocked. This change adds proper CDP
  configuration to enable downloads, matching the behavior already implemented in the TypeScript version of Stagehand.

#  what changed

  - Added CDP download behavior setup in LOCAL mode after browser connection
  - Implemented support for custom downloadsPath option in local_browser_launch_options, matching TypeScript implementation
  - Falls back to ./downloads in current working directory if no custom path is specified
  - Creates download directory automatically when using default path
  - Uses Chrome DevTools Protocol to send Browser.setDownloadBehavior command with:
    - behavior: "allow" to enable downloads
    - downloadPath set to the configured or default path
    - eventsEnabled: true for download event tracking