### PR TITLE
remove need for project id in Browserbase params if already passed to stagehand

### DIFF
--- a/.changeset/inventive-tangible-hyena.md
+++ b/.changeset/inventive-tangible-hyena.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+remove duplicate project id if already passed to Stagehand

--- a/stagehand/config.py
+++ b/stagehand/config.py
@@ -71,7 +71,9 @@ class StagehandConfig(BaseModel):
         alias="domSettleTimeoutMs",
         description="Timeout for DOM to settle (in ms)",
     )
-    browserbase_session_create_params: Optional[Union[BrowserbaseSessionCreateParams, dict[str, Any]]] = Field(
+    browserbase_session_create_params: Optional[
+        Union[BrowserbaseSessionCreateParams, dict[str, Any]]
+    ] = Field(
         None,
         alias="browserbaseSessionCreateParams",
         description="Browserbase session create params",
@@ -117,16 +119,16 @@ class StagehandConfig(BaseModel):
     )
 
     model_config = ConfigDict(populate_by_name=True)
-    
-    @field_validator('browserbase_session_create_params', mode='before')
+
+    @field_validator("browserbase_session_create_params", mode="before")
     @classmethod
     def validate_browserbase_params(cls, v, info):
         """Validate and convert browserbase session create params."""
-        if isinstance(v, dict) and 'project_id' not in v:
+        if isinstance(v, dict) and "project_id" not in v:
             values = info.data
-            project_id = values.get('project_id') or values.get('projectId')
+            project_id = values.get("project_id") or values.get("projectId")
             if project_id:
-                v = {**v, 'project_id': project_id}
+                v = {**v, "project_id": project_id}
         return v
 
     def with_overrides(self, **overrides) -> "StagehandConfig":

--- a/stagehand/config.py
+++ b/stagehand/config.py
@@ -1,8 +1,8 @@
 import os
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Literal, Optional, Union
 
 from browserbase.types import SessionCreateParams as BrowserbaseSessionCreateParams
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from stagehand.schemas import AvailableModel
 
@@ -71,7 +71,7 @@ class StagehandConfig(BaseModel):
         alias="domSettleTimeoutMs",
         description="Timeout for DOM to settle (in ms)",
     )
-    browserbase_session_create_params: Optional[BrowserbaseSessionCreateParams] = Field(
+    browserbase_session_create_params: Optional[Union[BrowserbaseSessionCreateParams, dict[str, Any]]] = Field(
         None,
         alias="browserbaseSessionCreateParams",
         description="Browserbase session create params",
@@ -117,6 +117,17 @@ class StagehandConfig(BaseModel):
     )
 
     model_config = ConfigDict(populate_by_name=True)
+    
+    @field_validator('browserbase_session_create_params', mode='before')
+    @classmethod
+    def validate_browserbase_params(cls, v, info):
+        """Validate and convert browserbase session create params."""
+        if isinstance(v, dict) and 'project_id' not in v:
+            values = info.data
+            project_id = values.get('project_id') or values.get('projectId')
+            if project_id:
+                v = {**v, 'project_id': project_id}
+        return v
 
     def with_overrides(self, **overrides) -> "StagehandConfig":
         """

--- a/tests/integration/local/test_core_local.py
+++ b/tests/integration/local/test_core_local.py
@@ -20,7 +20,7 @@ class TestStagehandLocalIntegration:
             self_heal=True,
             wait_for_captcha_solves=False,
             system_prompt="You are a browser automation assistant for testing purposes.",
-            model_client_options={"apiKey": os.getenv("MODEL_API_KEY") or os.getenv("OPENAI_API_KEY")},
+            model_client_options={"apiKey": os.getenv("MODEL_API_KEY")},
             use_api=False,
         )
 

--- a/tests/integration/local/test_core_local.py
+++ b/tests/integration/local/test_core_local.py
@@ -20,7 +20,7 @@ class TestStagehandLocalIntegration:
             self_heal=True,
             wait_for_captcha_solves=False,
             system_prompt="You are a browser automation assistant for testing purposes.",
-            model_client_options={"apiKey": os.getenv("MODEL_API_KEY")},
+            model_client_options={"apiKey": os.getenv("MODEL_API_KEY") or os.getenv("OPENAI_API_KEY")},
             use_api=False,
         )
 


### PR DESCRIPTION
Copying from Derek's branch: https://github.com/browserbase/stagehand-python/pull/170

# why

if you add custom browserbase create params, you need to include the project id even if the project id is already passed to the stagehand instance

# what changed

relaxed browserbase params definition and added a field validator to add project id from the stagehand config before validating structure

# test plan

ran tests with shell command
