### PR TITLE
Serialize ObserveResult before passing to draw_observe_overlay

### DIFF
--- a/stagehand/handlers/observe_handler.py
+++ b/stagehand/handlers/observe_handler.py
@@ -118,7 +118,10 @@ class ObserveHandler:
 
         # Draw overlay if requested
         if options.draw_overlay:
-            await draw_observe_overlay(self.stagehand_page, elements_with_selectors)
+            await draw_observe_overlay(
+                page=self.stagehand_page,
+                elements=[el.model_dump() for el in elements_with_selectors],
+            )
 
         # Return the list of results without trying to attach _llm_response
         return elements_with_selectors

--- a/stagehand/utils.py
+++ b/stagehand/utils.py
@@ -109,7 +109,7 @@ def format_simplified_tree(node: AccessibilityNode, level: int = 0) -> str:
     return result
 
 
-async def draw_observe_overlay(page, elements):
+async def draw_observe_overlay(page, elements: list[dict]):
     """
     Draw an overlay on the page highlighting the observed elements.
 


### PR DESCRIPTION
Currently the call to Playwright's `page.evaluate` for overlays is getting passed a list of `ObserveResult` objects which is not supported. This ends up becoming a list of `undefined` in javascript.

To fix this, the `ObserveResult` objects just need to be serialized using `model_dump` before passed to the `draw_observe_overlay` function. I added a simple type check as well which would have highlighted this issue.