### PR TITLE
Dump ObserveResult to dict before passing to draw_overlay (#198)

### DIFF
--- a/.changeset/outrageous-adept-hyena.md
+++ b/.changeset/outrageous-adept-hyena.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+Fix draw_overlay on env:LOCAL

--- a/stagehand/handlers/observe_handler.py
+++ b/stagehand/handlers/observe_handler.py
@@ -118,7 +118,10 @@ class ObserveHandler:
 
         # Draw overlay if requested
         if options.draw_overlay:
-            await draw_observe_overlay(self.stagehand_page, elements_with_selectors)
+            await draw_observe_overlay(
+                page=self.stagehand_page,
+                elements=[el.model_dump() for el in elements_with_selectors],
+            )
 
         # Return the list of results without trying to attach _llm_response
         return elements_with_selectors

--- a/stagehand/utils.py
+++ b/stagehand/utils.py
@@ -109,7 +109,7 @@ def format_simplified_tree(node: AccessibilityNode, level: int = 0) -> str:
     return result
 
 
-async def draw_observe_overlay(page, elements):
+async def draw_observe_overlay(page, elements: list[dict]):
     """
     Draw an overlay on the page highlighting the observed elements.
 


### PR DESCRIPTION
# why
Fixes an error with draw_overlay on elements

# what changed
Loads elements into a list[dict] with `modelDump()` from the observeResult Pydantic objects

# test plan
