### PR TITLE
Update quickstart.py as it's currently causing an error

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -44,7 +44,7 @@ async def main():
         # Extract companies using structured schema        
         companies_data = await page.extract(
           "Extract names and descriptions of 5 companies in batch 3",
-          schema=Companies
+          schema_definition=Companies
         )
         
         # Display results

--- a/stagehand/schemas.py
+++ b/stagehand/schemas.py
@@ -158,6 +158,14 @@ class ExtractOptions(StagehandBaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
+class AttrDict(dict):
+    """A dictionary that allows attribute-style access to its items."""
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__dict__ = self
+
+
 class ExtractResult(StagehandBaseModel):
     """
     Result of the 'extract' command.
@@ -170,6 +178,24 @@ class ExtractResult(StagehandBaseModel):
     # any fields from the extraction result based on the schema
 
     model_config = ConfigDict(extra="allow")  # Allow any extra fields
+
+    def __init__(self, **data):
+        """Initialize and recursively convert nested dictionaries to AttrDict objects."""
+        # Convert nested dictionaries to AttrDict for attribute access
+        converted_data = self._convert_to_attr_dict(data)
+        super().__init__(**converted_data)
+
+    def _convert_to_attr_dict(self, obj):
+        """Recursively convert dictionaries to AttrDict objects."""
+        if isinstance(obj, dict):
+            # Convert dict to AttrDict and recursively convert nested objects
+            attr_dict = AttrDict()
+            for key, value in obj.items():
+                attr_dict[key] = self._convert_to_attr_dict(value)
+            return attr_dict
+        elif isinstance(obj, list):
+            return [self._convert_to_attr_dict(item) for item in obj]
+        return obj
 
     def __getitem__(self, key):
         """


### PR DESCRIPTION
# why
Running quickstart.py on the currently published version of pypi throws an error:
`AttributeError: 'ExtractResult' object has no attribute 'companies'`

# what changed

I believe this is the right kwarg, but the code following this is still not quite working -- looks to me like the inner Company objects of the list are returned as a dict not as a pydantic object so I suspect there is a bug deeper in the code that is not fully recursively transforming the objects back. I updated the schemas.py file to fix this and it is now working but I'm lacking context on how you wanted it to work originally so this may not be appropriate.

# test plan
I have tested the code manually with quickstart.py