### PR TITLE
(nit): Remove naked debug print

### DIFF
--- a/stagehand/api.py
+++ b/stagehand/api.py
@@ -139,7 +139,6 @@ async def _execute(self, method: str, payload: dict[str, Any]) -> Any:
 
     # Convert snake_case keys to camelCase for the API
     modified_payload = convert_dict_keys_to_camel_case(payload)
-    print(modified_payload)
 
     # async with self._client:
     try:


### PR DESCRIPTION
# why
- Seeing non-logger, noisy, bare print statements like (`{'url': 'https://pacificpartn.identity.secureauth.com/SecureAuth9/SecureAuth.aspx', 'frameId': '21ECA2E4849B5239F74E5AD4134F57B6'}`) and (`{'sessionId': '707015c3-f4ee-4a7f-ac67-1fd5383421f9'}`) in logs while running stagehand. Not controlled by the `verbose` flag in `stagehand` init. 
- Want to remove, as it looks like a relic from debugging

# what changed
- Removed bare `print` debugging line

# test plan
- Stagehand no longer prints debug lines when running as production 
