### PR TITLE
customizable 'channel' parameter when launching playwright.chromium 

### DIFF
--- a/stagehand/browser.py
+++ b/stagehand/browser.py
@@ -186,6 +186,7 @@ async def connect_local_browser(
             "accept_downloads": local_browser_launch_options.get(
                 "acceptDownloads", True
             ),
+            "channel": local_browser_launch_options.get("channel"),
             "downloads_path": downloads_path,
             "args": local_browser_launch_options.get(
                 "args",


### PR DESCRIPTION
# why

`channel` parameter enables the use of different browsers, thereby allowing the AI to automatically control the browsing of certain websites that have restrictions (for instance, some video websites require the full version of Chrome to play videos)

# what changed

Add one line during preparing launch options

# test plan

It works. There are no major changes.

