### PR TITLE
update README for installing Chromium binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ cd stagehand-python
 
 # Install in editable mode with development dependencies
 pip install -r requirements.txt
+
+# Ensure that a Chromium binary exists for local testing
+python -m playwright install chromium
 ```
 
 


### PR DESCRIPTION
# why

When setting up the development environment for stagehand-python, we need to ensure that Chromium is installed for local testing with Playwright.

# what changed

Added a step to the README.md installation instructions to install Chromium using Playwright's installation command.

# test plan

N/A