### PR TITLE
feat: support both `api_key` and `apiKey` for CUA agent API keys

### DIFF
--- a/stagehand/agent/anthropic_cua.py
+++ b/stagehand/agent/anthropic_cua.py
@@ -58,9 +58,12 @@ class AnthropicCUAClient(AgentClient):
     ):
         super().__init__(model, instructions, config, logger, handler)
         self.experimental = experimental
-        self.anthropic_sdk_client = Anthropic(
-            api_key=config.options.get("apiKey") or os.getenv("ANTHROPIC_API_KEY")
-        )
+        api_key = None
+        if config and hasattr(config, 'options') and config.options:
+            api_key = config.options.get('api_key') or config.options.get('apiKey')
+        if not api_key:
+            api_key = os.getenv('ANTHROPIC_API_KEY')
+        self.anthropic_sdk_client = Anthropic(api_key=api_key)
 
         dimensions = (
             (viewport["width"], viewport["height"]) if viewport else (1288, 711)

--- a/stagehand/agent/google_cua.py
+++ b/stagehand/agent/google_cua.py
@@ -46,7 +46,7 @@ class GoogleCUAClient(AgentClient):
         # Match OpenAI pattern for API key handling
         api_key = None
         if config and hasattr(config, "options") and config.options:
-            api_key = config.options.get("apiKey")
+            api_key = config.options.get("api_key") or config.options.get("apiKey")
         if not api_key:
             api_key = os.getenv("GEMINI_API_KEY")
         if not api_key:

--- a/stagehand/agent/openai_cua.py
+++ b/stagehand/agent/openai_cua.py
@@ -40,9 +40,12 @@ class OpenAICUAClient(AgentClient):
     ):
         super().__init__(model, instructions, config, logger, handler)
         # TODO pass api key
-        self.openai_sdk_client = OpenAISDK(
-            api_key=config.options.get("apiKey") or os.getenv("OPENAI_API_KEY")
-        )
+        api_key = None
+        if config and hasattr(config, 'options') and config.options:
+            api_key = config.options.get('api_key') or config.options.get('apiKey')
+        if not api_key:
+            api_key = os.getenv('OPENAI_API_KEY')
+        self.openai_sdk_client = OpenAISDK(api_key=api_key)
 
         dimensions = (
             (viewport["width"], viewport["height"]) if viewport else (1288, 711)


### PR DESCRIPTION
# why

- Python docs and examples use `api_key` (snake_case), e.g. at https://docs.stagehand.dev/v2/basics/agent:
  ```python
  agent = stagehand.agent(
      model="claude-sonnet-4-20250514",
      instructions="You are a helpful assistant that can use a web browser.",
      options={"api_key": os.getenv("ANTHROPIC_API_KEY")},
  )
  await agent.execute("apply for a job at Browserbase")
  ```
- At https://www.browserbase.com/blog/evaluating-browser-agents, the `uvx create-browser-app --template gemini-cua` template also uses `api_key`.
- The CUA implementations were only reading `apiKey` from `config.options`, so running the generated Gemini example could error with:
  ```text
  GEMINI_API_KEY environment variable not set and not provided in config.
  ```
  even when `options={"api_key": ...}` was provided.
- This is unnecessarily confusing and inconsistent between docs, templates, and runtime.

# what changed

- **Anthropic CUA**
  - API key resolution order:
    1. `config.options["api_key"]`
    2. `config.options["apiKey"]`
    3. `ANTHROPIC_API_KEY` env var
  - Safely handle `config` / `config.options` being `None`.

- **OpenAI CUA**
  - API key resolution order:
    1. `config.options["api_key"]`
    2. `config.options["apiKey"]`
    3. `OPENAI_API_KEY` env var
  - Safely handle `config` / `config.options` being `None`.

- **Google CUA (Gemini)**
  - API key resolution order:
    1. `config.options["api_key"]`
    2. `config.options["apiKey"]`
    3. `GEMINI_API_KEY` env var
    4. Raise `ValueError` if still missing (same behavior as before).
  - Switched env var name and error messaging to `GEMINI_API_KEY`, matching the Gemini usage and the generated template.

# test plan

- Generate and run the Gemini example:
  - `uvx create-browser-app --template gemini-cua`
  - Ensure it passes `options={"api_key": os.getenv("GEMINI_API_KEY")}`.
  - Run `python main.py` and verify it no longer fails with a missing GEMINI_API_KEY error when `api_key` is set.

- Smoke-test Anthropic and OpenAI CUA:
  - For each:
    - `options={"api_key": ...}`
    - `options={"apiKey": ...}`
    - Only the respective `*_API_KEY` env var set, with `options` omitted.
  - Confirm authentication works and no `AttributeError` is raised when `config` / `options` is absent.