### PR TITLE
Fix Google CUA clear_before_typing behavior in Python client

### DIFF
--- a/stagehand/agent/google_cua.py
+++ b/stagehand/agent/google_cua.py
@@ -238,6 +238,8 @@ class GoogleCUAClient(AgentClient):
                     "x": x,
                     "y": y,
                     "press_enter_after": action_args.get("press_enter", False),
+                    # Default to True to match TS behavior: clear field before typing
+                    "clear_before_typing": action_args.get("clear_before_typing", True),
                 }
             elif action_name == "key_combination":
                 action_type_str = "keypress"

--- a/stagehand/types/agent.py
+++ b/stagehand/types/agent.py
@@ -38,6 +38,7 @@ class TypeAction(BaseModel):
     x: Optional[int] = None
     y: Optional[int] = None
     press_enter_after: Optional[bool] = False
+    clear_before_typing: Optional[bool] = False
 
 
 class KeyPressAction(BaseModel):

--- a/tests/unit/handlers/test_cua_handler.py
+++ b/tests/unit/handlers/test_cua_handler.py
@@ -1,0 +1,212 @@
+"""Test CUAHandler functionality for Computer Use Agent action execution"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from stagehand.handlers.cua_handler import CUAHandler
+from stagehand.types.agent import TypeAction, AgentAction, ClickAction
+
+
+class TestCUAHandlerInitialization:
+    """Test CUAHandler initialization and setup"""
+
+    def test_cua_handler_creation(self):
+        """Test basic CUAHandler creation"""
+        mock_stagehand = MagicMock()
+        mock_page = MagicMock()
+        mock_logger = MagicMock()
+
+        handler = CUAHandler(
+            stagehand=mock_stagehand,
+            page=mock_page,
+            logger=mock_logger,
+        )
+
+        assert handler.stagehand == mock_stagehand
+        assert handler.page == mock_page
+        assert handler.logger == mock_logger
+
+
+class TestTypeActionClearBeforeTyping:
+    """Test clear_before_typing functionality in type actions"""
+
+    @pytest.fixture
+    def cua_handler(self):
+        """Create a CUAHandler with mocked dependencies"""
+        mock_stagehand = MagicMock()
+        mock_page = MagicMock()
+        mock_page.mouse = MagicMock()
+        mock_page.mouse.click = AsyncMock()
+        mock_page.keyboard = MagicMock()
+        mock_page.keyboard.type = AsyncMock()
+        mock_page.keyboard.press = AsyncMock()
+        mock_page.url = "https://example.com"
+        mock_logger = MagicMock()
+
+        handler = CUAHandler(
+            stagehand=mock_stagehand,
+            page=mock_page,
+            logger=mock_logger,
+        )
+        # Mock internal methods
+        handler._update_cursor_position = AsyncMock()
+        handler.handle_page_navigation = AsyncMock()
+
+        return handler
+
+    @pytest.mark.asyncio
+    async def test_type_without_clear_uses_single_click(self, cua_handler):
+        """Test that typing without clear_before_typing uses single click"""
+        type_action = TypeAction(
+            type="type",
+            text="hello world",
+            x=100,
+            y=200,
+            clear_before_typing=False,
+        )
+        agent_action = AgentAction(
+            action_type="type",
+            action=type_action,
+        )
+
+        result = await cua_handler.perform_action(agent_action)
+
+        assert result["success"] is True
+        # Should have called single click (click_count defaults to 1)
+        cua_handler.page.mouse.click.assert_called_once_with(100, 200)
+        cua_handler.page.keyboard.type.assert_called_once_with("hello world")
+
+    @pytest.mark.asyncio
+    async def test_type_with_clear_uses_triple_click(self, cua_handler):
+        """Test that typing with clear_before_typing=True uses triple click to select all"""
+        type_action = TypeAction(
+            type="type",
+            text="new text",
+            x=100,
+            y=200,
+            clear_before_typing=True,
+        )
+        agent_action = AgentAction(
+            action_type="type",
+            action=type_action,
+        )
+
+        result = await cua_handler.perform_action(agent_action)
+
+        assert result["success"] is True
+        # Should have called triple click to select all text
+        cua_handler.page.mouse.click.assert_called_once_with(100, 200, click_count=3)
+        cua_handler.page.keyboard.type.assert_called_once_with("new text")
+
+    @pytest.mark.asyncio
+    async def test_type_with_clear_no_coordinates_uses_keyboard_shortcuts(self, cua_handler):
+        """Test that clear_before_typing without coordinates falls back to keyboard shortcuts"""
+        type_action = TypeAction(
+            type="type",
+            text="new text",
+            x=None,
+            y=None,
+            clear_before_typing=True,
+        )
+        agent_action = AgentAction(
+            action_type="type",
+            action=type_action,
+        )
+
+        result = await cua_handler.perform_action(agent_action)
+
+        assert result["success"] is True
+        # Should have called keyboard shortcuts for select all
+        calls = cua_handler.page.keyboard.press.call_args_list
+        key_calls = [call[0][0] for call in calls]
+        assert "Meta+a" in key_calls or "Control+a" in key_calls
+        assert "Backspace" in key_calls
+        cua_handler.page.keyboard.type.assert_called_once_with("new text")
+
+    @pytest.mark.asyncio
+    async def test_type_default_clear_before_typing_is_false(self, cua_handler):
+        """Test that clear_before_typing defaults to False"""
+        type_action = TypeAction(
+            type="type",
+            text="hello",
+            x=100,
+            y=200,
+            # clear_before_typing not specified, should default to False
+        )
+        agent_action = AgentAction(
+            action_type="type",
+            action=type_action,
+        )
+
+        result = await cua_handler.perform_action(agent_action)
+
+        assert result["success"] is True
+        # Should use single click (not triple click)
+        cua_handler.page.mouse.click.assert_called_once_with(100, 200)
+
+    @pytest.mark.asyncio
+    async def test_type_with_press_enter_after(self, cua_handler):
+        """Test that press_enter_after works with clear_before_typing"""
+        type_action = TypeAction(
+            type="type",
+            text="search query",
+            x=100,
+            y=200,
+            clear_before_typing=True,
+            press_enter_after=True,
+        )
+        agent_action = AgentAction(
+            action_type="type",
+            action=type_action,
+        )
+
+        result = await cua_handler.perform_action(agent_action)
+
+        assert result["success"] is True
+        # Should have triple-clicked, typed, then pressed Enter
+        cua_handler.page.mouse.click.assert_called_once_with(100, 200, click_count=3)
+        cua_handler.page.keyboard.type.assert_called_once_with("search query")
+        # Check that Enter was pressed
+        enter_calls = [
+            call for call in cua_handler.page.keyboard.press.call_args_list
+            if call[0][0] == "Enter"
+        ]
+        assert len(enter_calls) == 1
+
+
+class TestTypeActionModel:
+    """Test TypeAction Pydantic model"""
+
+    def test_type_action_has_clear_before_typing_field(self):
+        """Test that TypeAction model has clear_before_typing field"""
+        action = TypeAction(
+            type="type",
+            text="test",
+            clear_before_typing=True,
+        )
+        assert action.clear_before_typing is True
+
+    def test_type_action_clear_before_typing_defaults_to_false(self):
+        """Test that clear_before_typing defaults to False"""
+        action = TypeAction(
+            type="type",
+            text="test",
+        )
+        assert action.clear_before_typing is False
+
+    def test_type_action_with_all_fields(self):
+        """Test TypeAction with all fields populated"""
+        action = TypeAction(
+            type="type",
+            text="hello@example.com",
+            x=150,
+            y=250,
+            press_enter_after=True,
+            clear_before_typing=True,
+        )
+        assert action.type == "type"
+        assert action.text == "hello@example.com"
+        assert action.x == 150
+        assert action.y == 250
+        assert action.press_enter_after is True
+        assert action.clear_before_typing is True


### PR DESCRIPTION
# why

Stagehand’s Google CUA integration was ignoring `clear_before_typing` for `type_text_at` actions in the Python client.  
As a result, when Gemini tried to overwrite input fields (e.g. email search fields), text kept getting appended instead of replaced, even when the model explicitly set `clear_before_typing=True`.  
The TypeScript client already behaves correctly; this PR brings the Python client in line with that behavior.

# what changed

- Added `clear_before_typing: Optional[bool] = False` to [TypeAction] in [stagehand/types/agent.py] so the flag is representable in the Python action model.
- Updated [GoogleCUAClient] ([stagehand/agent/google_cua.py]) to:
  - Read `clear_before_typing` from Gemini `type_text_at` tool call args.
  - Default `clear_before_typing` to `True` when not provided, matching the TS client’s behavior.
- Updated [CUAHandler.perform_action] ([stagehand/handlers/cua_handler.py]) for `action_type == "type"`:
  - When coordinates are provided and `clear_before_typing=True`, perform a **triple-click** at `(x, y)` to select all existing text, then type the new text so it replaces the selection.
  - When coordinates are provided and `clear_before_typing=False`, keep the existing behavior: single click then type (append).
  - When no coordinates are provided but `clear_before_typing=True`, fall back to `Meta+a` / `Control+a` + `Backspace` before typing.
- Added unit tests in [tests/unit/handlers/test_cua_handler.py] to cover:
  - Single-click vs triple-click paths based on `clear_before_typing`.
  - Keyboard-shortcut fallback when no coordinates.
  - `press_enter_after` interaction with `clear_before_typing`.
  - [TypeAction] model defaults and `clear_before_typing` field behavior.

# test plan

- Unit tests:
  - `pytest tests/unit/handlers/test_cua_handler.py -v`
- Manual verification (optional but performed while developing the fix):
  - Run attached `python test_clear_typing.py` to:
    - Open a local browser with a simple HTML form.
    - Confirm that:
      - With `clear_before_typing=False`, text is appended to the pre-filled field.
      - With `clear_before_typing=True`, the field is cleared (via triple-click select-all) and only the new text remains, consistently across multiple attempts.
[test_clear_typing.py](https://github.com/user-attachments/files/24053065/test_clear_typing.py)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Python Google CUA client so type_text_at honors clear_before_typing, matching TS behavior and preventing accidental text appends. Defaults to clearing before typing for Gemini tool calls and adds reliable field clearing.

- **Bug Fixes**
  - Added clear_before_typing to TypeAction (default False for backward compatibility).
  - Mapped Gemini type_text_at to default clear_before_typing=True in google_cua.py.
  - In CUAHandler:
    - With coords + clear: triple-click to select all, then type.
    - With coords + no clear: single-click, then type.
    - No coords + clear: use Meta/Control+a + Backspace before typing.
  - Added unit tests for click paths, keyboard fallback, press_enter_after, and model defaults.

<sup>Written for commit 1801c1ff39a2cf45cc9a5bfe81d7bc597cc64c44. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

