### PR TITLE
Bump version for patch fix in #251

### DIFF
--- a/.changeset/groovy-mouflon-of-realization.md
+++ b/.changeset/groovy-mouflon-of-realization.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+Fix active page context


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare a patch release to ship the active page context fix. Adds a changeset for stagehand to bump the version.

<sup>Written for commit f81b4bdbaa10e3ad7b88dcf27738ce338767359a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

