### PR TITLE
Added logging example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ pip install stagehand-alpha
 uv run python examples/local_example.py
 ```
 
+## Streaming logging example
+
+See [`examples/logging_example.py`](examples/logging_example.py) for a remote-only flow that streams `StreamEvent`s with `verbose=2`, `stream_response=True`, and `x_stream_response="true"` so you can watch the SDK’s logs as they arrive.
+
+```bash
+uv run python examples/logging_example.py
+```
+
 <details>
 <summary><strong>Local development</strong></summary>
 

--- a/examples/logging_example.py
+++ b/examples/logging_example.py
@@ -1,0 +1,81 @@
+"""
+Example demonstrating how to run an extract() call with streaming logs enabled
+using the remote Browserbase Stagehand service.
+
+Required environment variables:
+- BROWSERBASE_API_KEY: Your Browserbase API key
+- BROWSERBASE_PROJECT_ID: Your Browserbase project ID
+- MODEL_API_KEY: Your OpenAI API key
+"""
+
+import os
+
+from stagehand import AsyncStagehand
+
+
+async def main() -> None:
+    # Create client using environment variables
+    async with AsyncStagehand(
+        browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
+        browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
+        model_api_key=os.environ.get("MODEL_API_KEY"),
+    ) as client:
+        # Start a new browser session with verbose logging enabled
+        session = await client.sessions.create(
+            model_name="openai/gpt-5-nano",
+            verbose=2,
+        )
+
+        print(f"Session started: {session.id}")
+
+        try:
+            print("Navigating to https://www.example.com...")
+            await session.navigate(url="https://www.example.com")
+            print("Navigation complete.")
+
+            print("\nExtracting the page heading with streaming logs...")
+            stream = await session.extract(
+                instruction="Extract the text of the top-level heading on this page.",
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "headingText": {
+                            "type": "string",
+                            "description": "The text content of the top-level heading",
+                        },
+                        "subheadingText": {
+                            "type": "string",
+                            "description": "Optional subheading text below the main heading",
+                        },
+                    },
+                    "required": ["headingText"],
+                },
+                stream_response=True,
+                x_stream_response="true",
+            )
+
+            result_payload: object | None = None
+            async for event in stream:
+                if event.type == "log":
+                    print(f"[log] {event.data.message}")
+                    continue
+
+                status = event.data.status
+                print(f"[system] status={status}")
+                if status == "finished":
+                    result_payload = event.data.result
+                elif status == "error":
+                    error_message = event.data.error or "unknown error"
+                    raise RuntimeError(f"Stream reported error: {error_message}")
+
+            print("Extract completed successfully!")
+            print(f"Payload received: {result_payload}")
+        finally:
+            await session.end()
+            print("\nSession ended.")
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())


### PR DESCRIPTION
# why
Added example of how to enable streaming logs.
# what changed
Just new example file + readme
# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds examples/logging_example.py that streams Stagehand logs during extract() using AsyncStagehand with Browserbase (verbose=2, stream_response=True, x_stream_response="true"). Updates README with a “Streaming logging example” section and a uv run command.

<sup>Written for commit 5e67ffaf247607597f405452c70e25c2f34af5ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

