### PR TITLE
Add back in x-sent-at so that start_time and end_time work again

### DIFF
--- a/src/stagehand/_client.py
+++ b/src/stagehand/_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import datetime
 from typing import TYPE_CHECKING, Any, Mapping
 from typing_extensions import Self, Literal, override
 
@@ -224,6 +225,7 @@ class Stagehand(SyncAPIClient):
             **super().default_headers,
             "x-language": "python",
             "x-sdk-version": __version__,
+            "x-sent-at": datetime.datetime.now().isoformat(),
             "X-Stainless-Async": "false",
             **self._custom_headers,
         }
@@ -514,6 +516,7 @@ class AsyncStagehand(AsyncAPIClient):
             **super().default_headers,
             "x-language": "python",
             "x-sdk-version": __version__,
+            "x-sent-at": datetime.datetime.now().isoformat(),
             "X-Stainless-Async": f"async:{get_async_library()}",
             **self._custom_headers,
         }


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored the x-sent-at header on all Python SDK requests so the server can compute start_time and end_time again. Added x-sent-at: datetime.datetime.now().isoformat() to default headers in both sync and async clients.

<sup>Written for commit 564f794ad9a027bdff08a982d9f8e159ca338aac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

