### PR TITLE
make AsyncSession and Session subclass SessionStartResponse for compat with sdk docs patterns

### DIFF
--- a/src/stagehand/resources/sessions_helpers.py
+++ b/src/stagehand/resources/sessions_helpers.py
@@ -59,7 +59,7 @@ class SessionsResourceWithHelpers(SessionsResource):
             extra_body=extra_body,
             timeout=timeout,
         )
-        return Session(self._client, start_response.data.session_id)
+        return Session(self._client, start_response.data.session_id, data=start_response.data, success=start_response.success)
 
 
 class AsyncSessionsResourceWithHelpers(AsyncSessionsResource):
@@ -86,7 +86,7 @@ class AsyncSessionsResourceWithHelpers(AsyncSessionsResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
     ) -> AsyncSession:
-        start_response = await self.start(
+        start_response: SessionStartResponse = await self.start(
             model_name=model_name,
             act_timeout_ms=act_timeout_ms,
             browser=browser,
@@ -107,4 +107,4 @@ class AsyncSessionsResourceWithHelpers(AsyncSessionsResource):
             extra_body=extra_body,
             timeout=timeout,
         )
-        return AsyncSession(self._client, start_response.data.session_id)
+        return AsyncSession(self._client, start_response.data.session_id, data=start_response.data, success=start_response.success)

--- a/src/stagehand/session.py
+++ b/src/stagehand/session.py
@@ -16,6 +16,7 @@ from .types import (
     session_navigate_params,
 )
 from ._types import Body, Omit, Query, Headers, NotGiven, omit, not_given
+from .types.session_start_response import SessionStartResponse, Data as SessionStartResponseData
 from .types.session_act_response import SessionActResponse
 from .types.session_end_response import SessionEndResponse
 from .types.session_execute_response import SessionExecuteResponse
@@ -36,12 +37,15 @@ if TYPE_CHECKING:
     from ._client import Stagehand, AsyncStagehand
 
 
-class Session:
+class Session(SessionStartResponse):
     """A Stagehand session bound to a specific `session_id`."""
 
-    def __init__(self, client: Stagehand, id: str) -> None:
+    def __init__(self, client: Stagehand, id: str, data: SessionStartResponseData, success: bool) -> None:
         self._client = client
         self.id = id
+        # in case user tries to use client.sessions.start(...) return value as a SessionStartResponse dataclass/dict
+        super().__init__(data=data, success=success)
+    
 
     def navigate(
         self,
@@ -158,12 +162,13 @@ class Session:
         )
 
 
-class AsyncSession:
+class AsyncSession(SessionStartResponse):
     """Async variant of `Session`."""
 
-    def __init__(self, client: AsyncStagehand, id: str) -> None:
+    def __init__(self, client: AsyncStagehand, id: str, data: SessionStartResponseData, success: bool) -> None:
         self._client = client
         self.id = id
+        super().__init__(data=data, success=success)
 
     async def navigate(
         self,


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Session and AsyncSession subclass SessionStartResponse so users can access start response fields directly, matching SDK docs patterns. Updates helper create() to populate the new base fields without changing the public API.

- **Refactors**
  - Made Session and AsyncSession inherit from SessionStartResponse.
  - Helper create() now passes data and success from start() into the constructors.
  - Added explicit typing for Async start() response.

<sup>Written for commit 3bcc3a919378fb7d07df19e8712f53012804892c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

