### PR TITLE
Added a minimal playwright Page helper

### DIFF
--- a/examples/playwright_page_example.py
+++ b/examples/playwright_page_example.py
@@ -1,0 +1,118 @@
+"""
+Example: use a Playwright Page with the Stagehand Python SDK.
+
+What this demonstrates:
+- Start a Stagehand session (remote Stagehand API / Browserbase browser)
+- Attach Playwright to the same browser via CDP (`cdp_url`)
+- Pass the Playwright `page` into `session.observe/act/extract` so Stagehand
+  auto-detects the correct `frame_id` for that page.
+
+Environment variables required:
+- MODEL_API_KEY
+- BROWSERBASE_API_KEY
+- BROWSERBASE_PROJECT_ID
+
+Optional:
+- STAGEHAND_BASE_URL (defaults to https://api.stagehand.browserbase.com)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Optional
+
+from stagehand import Stagehand
+
+
+def main() -> None:
+    model_api_key = os.environ.get("MODEL_API_KEY")
+    if not model_api_key:
+        sys.exit("Set the MODEL_API_KEY environment variable to run this example.")
+
+    bb_api_key = os.environ.get("BROWSERBASE_API_KEY")
+    bb_project_id = os.environ.get("BROWSERBASE_PROJECT_ID")
+    if not bb_api_key or not bb_project_id:
+        sys.exit(
+            "Set BROWSERBASE_API_KEY and BROWSERBASE_PROJECT_ID to run this example."
+        )
+
+    try:
+        from playwright.sync_api import sync_playwright  # type: ignore[import-not-found]
+    except Exception:
+        sys.exit(
+            "Playwright is not installed. Install it with:\n"
+            "  uv pip install playwright\n"
+            "and ensure browsers are installed (e.g. `playwright install chromium`)."
+        )
+
+    session_id: Optional[str] = None
+
+    with Stagehand(
+        server="remote",
+        browserbase_api_key=bb_api_key,
+        browserbase_project_id=bb_project_id,
+        model_api_key=model_api_key,
+    ) as client:
+        print("⏳ Starting Stagehand session...")
+        session = client.sessions.create(
+            model_name="openai/gpt-5-nano",
+            browser={"type": "browserbase"},
+        )
+        session_id = session.id
+
+        cdp_url = session.data.cdp_url
+        if not cdp_url:
+            sys.exit(
+                "No cdp_url returned from the API for this session; cannot attach Playwright."
+            )
+
+        print(f"✅ Session started: {session_id}")
+        print("🔌 Connecting Playwright to the same browser over CDP...")
+
+        with sync_playwright() as p:
+            # Attach to the same browser session Stagehand is controlling.
+            browser = p.chromium.connect_over_cdp(cdp_url)
+            try:
+                # Reuse an existing context/page if present; otherwise create one.
+                context = browser.contexts[0] if browser.contexts else browser.new_context()
+                page = context.pages[0] if context.pages else context.new_page()
+
+                page.goto("https://example.com", wait_until="domcontentloaded")
+
+                print("👀 Stagehand.observe(page=...) ...")
+                actions = session.observe(
+                    instruction="Find the most relevant click target on this page",
+                    page=page,
+                )
+                print(f"Observed {len(actions.data.result)} actions")
+
+                print("🧠 Stagehand.extract(page=...) ...")
+                extracted = session.extract(
+                    instruction="Extract the page title and the primary heading (h1) text",
+                    schema={
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "h1": {"type": "string"},
+                        },
+                        "required": ["title", "h1"],
+                        "additionalProperties": False,
+                    },
+                    page=page,
+                )
+                print("Extracted:", extracted.data.result)
+
+                print("🖱️ Stagehand.act(page=...) ...")
+                _ = session.act(
+                    input="Click the 'More information' link",
+                    page=page,
+                )
+                print("Done.")
+            finally:
+                browser.close()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_session_page_param.py
+++ b/tests/test_session_page_param.py
@@ -1,0 +1,155 @@
+# Manually maintained tests for Playwright page helpers (non-generated).
+
+from __future__ import annotations
+
+import json
+import os
+from typing import cast, Any
+
+import httpx
+import pytest
+from respx import MockRouter
+from respx.models import Call
+
+from stagehand import Stagehand, AsyncStagehand
+
+
+base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
+
+
+class _SyncCDP:
+    def __init__(self, frame_id: str) -> None:
+        self._frame_id = frame_id
+
+    def send(self, method: str) -> dict[str, Any]:
+        assert method == "Page.getFrameTree"
+        return {"frameTree": {"frame": {"id": self._frame_id}}}
+
+
+class _SyncContext:
+    def __init__(self, frame_id: str) -> None:
+        self._frame_id = frame_id
+
+    def new_cdp_session(self, _page: Any) -> _SyncCDP:
+        return _SyncCDP(self._frame_id)
+
+
+class _SyncPage:
+    def __init__(self, frame_id: str) -> None:
+        self.context = _SyncContext(frame_id)
+
+
+class _AsyncCDP:
+    def __init__(self, frame_id: str) -> None:
+        self._frame_id = frame_id
+
+    async def send(self, method: str) -> dict[str, Any]:
+        assert method == "Page.getFrameTree"
+        return {"frameTree": {"frame": {"id": self._frame_id}}}
+
+
+class _AsyncContext:
+    def __init__(self, frame_id: str) -> None:
+        self._frame_id = frame_id
+
+    async def new_cdp_session(self, _page: Any) -> _AsyncCDP:
+        return _AsyncCDP(self._frame_id)
+
+
+class _AsyncPage:
+    def __init__(self, frame_id: str) -> None:
+        self.context = _AsyncContext(frame_id)
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_session_act_injects_frame_id_from_page(respx_mock: MockRouter, client: Stagehand) -> None:
+    session_id = "00000000-0000-0000-0000-000000000000"
+    frame_id = "frame-123"
+
+    respx_mock.post("/v1/sessions/start").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"available": True, "sessionId": session_id}},
+        )
+    )
+
+    act_route = respx_mock.post(f"/v1/sessions/{session_id}/act").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"result": {"success": True, "message": "", "actionDescription": "", "actions": []}}},
+        )
+    )
+
+    session = client.sessions.create(model_name="openai/gpt-5-nano")
+    session.act(input="click something", page=_SyncPage(frame_id))
+
+    assert act_route.called is True
+    first_call = cast(Call, act_route.calls[0])
+    request_body = json.loads(first_call.request.content)
+    assert request_body["frameId"] == frame_id
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_session_act_prefers_explicit_frame_id_over_page(respx_mock: MockRouter, client: Stagehand) -> None:
+    session_id = "00000000-0000-0000-0000-000000000000"
+
+    respx_mock.post("/v1/sessions/start").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"available": True, "sessionId": session_id}},
+        )
+    )
+
+    act_route = respx_mock.post(f"/v1/sessions/{session_id}/act").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"result": {"success": True, "message": "", "actionDescription": "", "actions": []}}},
+        )
+    )
+
+    session = client.sessions.create(model_name="openai/gpt-5-nano")
+
+    class _ExplodingContext:
+        def new_cdp_session(self, _page: Any) -> None:
+            raise AssertionError("new_cdp_session should not be called when frame_id is provided")
+
+    class _ExplodingPage:
+        context = _ExplodingContext()
+
+    session.act(input="click something", frame_id="explicit-frame", page=_ExplodingPage())
+
+    assert act_route.called is True
+    first_call = cast(Call, act_route.calls[0])
+    request_body = json.loads(first_call.request.content)
+    assert request_body["frameId"] == "explicit-frame"
+
+
+@pytest.mark.respx(base_url=base_url)
+async def test_async_session_act_injects_frame_id_from_page(
+    respx_mock: MockRouter, async_client: AsyncStagehand
+) -> None:
+    session_id = "00000000-0000-0000-0000-000000000000"
+    frame_id = "frame-async-456"
+
+    respx_mock.post("/v1/sessions/start").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"available": True, "sessionId": session_id}},
+        )
+    )
+
+    act_route = respx_mock.post(f"/v1/sessions/{session_id}/act").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"result": {"success": True, "message": "", "actionDescription": "", "actions": []}}},
+        )
+    )
+
+    session = await async_client.sessions.create(model_name="openai/gpt-5-nano")
+    await session.act(input="click something", page=_AsyncPage(frame_id))
+
+    assert act_route.called is True
+    first_call = cast(Call, act_route.calls[0])
+    request_body = json.loads(first_call.request.content)
+    assert request_body["frameId"] == frame_id
+


### PR DESCRIPTION
# why
Added the ability to pass in a playwright `Page`. 
# what changed
Uses duck typing so that stagehand-python isn't reliant on playwright. 
# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Playwright Page support to session methods to auto-detect and pass the correct frame_id, improving integration without adding a Playwright dependency. Works for both sync and async Playwright pages and keeps explicit frame_id as the priority.

- **New Features**
  - Added page param to Session and AsyncSession navigate/act/observe/extract/execute.
  - Auto-injects frame_id via Playwright CDP (duck typing; Playwright not required).
  - Example shows connecting Playwright over CDP and using page with Stagehand.
  - Tests cover sync/async pages and prefer explicit frame_id over page-derived.

<sup>Written for commit 7da93345265d9c272276cb4aa72d908c12af78c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

