### PR TITLE
Standardize README with Stagehand branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,67 @@
-# Stagehand Python API Library
+<div id="toc" align="center" style="margin-bottom: 0;">
+  <ul style="list-style: none; margin: 0; padding: 0;">
+    <a href="https://stagehand.dev">
+      <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="media/dark_logo.png" />
+        <img alt="Stagehand" src="media/light_logo.png" width="200" style="margin-right: 30px;" />
+      </picture>
+    </a>
+  </ul>
+</div>
+<p align="center">
+  <strong>The AI Browser Automation Framework</strong><br>
+  <a href="https://docs.stagehand.dev/v3/sdk/python">Read the Docs</a>
+</p>
 
-[![PyPI version](https://img.shields.io/pypi/v/stagehand-alpha.svg?label=pypi%20(stable))](https://pypi.org/project/stagehand-alpha/)
+<p align="center">
+  <a href="https://github.com/browserbase/stagehand/tree/main?tab=MIT-1-ov-file#MIT-1-ov-file">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="media/dark_license.svg" />
+      <img alt="MIT License" src="media/light_license.svg" />
+    </picture>
+  </a>
+  <a href="https://stagehand.dev/discord">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="media/dark_discord.svg" />
+      <img alt="Discord Community" src="media/light_discord.svg" />
+    </picture>
+  </a>
+</p>
 
-The Stagehand Python SDK provides convenient access to the [Stagehand REST API](https://docs.stagehand.dev) from applications written in Python.
+<p align="center">
+	<a href="https://trendshift.io/repositories/12122" target="_blank"><img src="https://trendshift.io/api/badge/repositories/12122" alt="browserbase%2Fstagehand | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+</p>
 
-It is generated with [Stainless](https://www.stainless.com/).
+<p align="center">
+If you're looking for other languages, you can find them
+<a href="https://docs.stagehand.dev/v3/first-steps/introduction"> here</a>
+</p>
+
+<div align="center" style="display: flex; align-items: center; justify-content: center; gap: 4px; margin-bottom: 0;">
+  <b>Vibe code</b>
+  <span style="font-size: 1.05em;"> Stagehand with </span>
+  <a href="https://director.ai" style="display: flex; align-items: center;">
+    <span>Director</span>
+  </a>
+  <span> </span>
+  <picture>
+    <img alt="Director" src="media/director_icon.svg" width="25" />
+  </picture>
+</div>
+
+## What is Stagehand?
+
+Stagehand is a browser automation framework used to control web browsers with natural language and code. By combining the power of AI with the precision of code, Stagehand makes web automation flexible, maintainable, and actually reliable.
+
+## Why Stagehand?
+
+Most existing browser automation tools either require you to write low-level code in a framework like Selenium, Playwright, or Puppeteer, or use high-level agents that can be unpredictable in production. By letting developers choose what to write in code vs. natural language (and bridging the gap between the two) Stagehand is the natural choice for browser automations in production.
+
+1. **Choose when to write code vs. natural language**: use AI when you want to navigate unfamiliar pages, and use code when you know exactly what you want to do.
+
+2. **Go from AI-driven to repeatable workflows**: Stagehand lets you preview AI actions before running them, and also helps you easily cache repeatable actions to save time and tokens.
+
+3. **Write once, run forever**: Stagehand's auto-caching combined with self-healing remembers previous actions, runs without LLM inference, and knows when to involve AI whenever the website changes and your automation breaks.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Replace README header with standardized Stagehand branding
- Update docs URL to /v3/sdk/python
- Add 'What is Stagehand?' and 'Why Stagehand?' sections

## Changes
This PR updates the README.md to match the standard Stagehand branding and includes:
- Visual branding elements (logo with dark/light mode support)
- License and Discord badges
- Comprehensive "What is Stagehand?" and "Why Stagehand?" sections
- Updated documentation links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the README with Stagehand branding and adds a concise product overview. Updates docs links to point to the v3 Python SDK.

- New Features
  - Branded header with dark/light logo and tagline
  - MIT license, Discord, and Trendshift badges
  - “What is Stagehand?” and “Why Stagehand?” sections highlighting code + natural language, caching, and self-healing
  - Updated docs links to /v3/sdk/python and added cross-language docs link
  - Removed outdated header and PyPI badge

<sup>Written for commit e16747bc04f3298fb38de4ae62abe27494889684. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

