### PR TITLE
bump stagehand version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
-name = "stagehand-alpha"
-version = "0.3.1"
-description = "The official Python library for the stagehand API"
+name = "stagehand"
+version = "3.4.0"
+description = "Python SDK for Stagehand"
 dynamic = ["readme"]
-license = "Apache-2.0"
+license = "MIT"
 authors = [
-{ name = "Stagehand", email = "" },
+{ name = "Browserbase", email = "support@browserbase.com" },
 ]
 
 dependencies = [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the Python package to "stagehand" and bumped the version to 3.4.0. Updated metadata: description, MIT license, and Browserbase support contact.

- **Migration**
  - Replace dependency "stagehand-alpha" with "stagehand>=3.4.0".
  - Review MIT license compliance if needed.

<sup>Written for commit 8477f9794694a633fab8cd13b3eb86a3f40aa676. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

