### PR TITLE
Fix variable handling in actHandler

### DIFF
--- a/.changeset/modest-oyster-from-hyperborea.md
+++ b/.changeset/modest-oyster-from-hyperborea.md
@@ -1,0 +1,5 @@
+---
+"stagehand": patch
+---
+
+Fix variable replacement in actHandler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stagehand"
-version = "0.5.9"
+version = "0.5.10"
 description = "Python SDK for Stagehand"
 readme = "README.md"
 classifiers = [ "Programming Language :: Python :: 3", "License :: OSI Approved :: MIT License", "Operating System :: OS Independent",]

--- a/stagehand/handlers/act_handler.py
+++ b/stagehand/handlers/act_handler.py
@@ -96,7 +96,7 @@ class ActHandler:
             if options.get("variables"):
                 variables = options.get("variables", {})
                 element_to_act_on.arguments = [
-                    str(arg).replace(f"%{key}%", str(value))
+                    str(arg).replace(f"{key}", str(value))
                     for arg in element_to_act_on.arguments or []
                     for key, value in variables.items()
                 ]


### PR DESCRIPTION
Variable values were only being replaced if the LLM replied with the percentage sign wrapped values `%key%`. This PR addresses that and replaces just `key` suggested values

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix variable replacement in actHandler so plain keys are substituted, not only %key% tokens. This ensures suggested values populate element arguments reliably.

- **Bug Fixes**
  - Replace f"%{key}%" matching with f"{key}" when mapping variables into element_to_act_on.arguments.

<sup>Written for commit 1350abef07b0d0b82f0a9943999ec03811a27419. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand-python/pull/310">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

