### PR TITLE
Accept both %-wrapped and non-wrapped variable arguments in act

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stagehand"
-version = "0.5.10"
+version = "0.5.11"
 description = "Python SDK for Stagehand"
 readme = "README.md"
 classifiers = [ "Programming Language :: Python :: 3", "License :: OSI Approved :: MIT License", "Operating System :: OS Independent",]

--- a/stagehand/handlers/act_handler.py
+++ b/stagehand/handlers/act_handler.py
@@ -95,11 +95,16 @@ class ActHandler:
             # Substitute variables in arguments
             if options.get("variables"):
                 variables = options.get("variables", {})
-                element_to_act_on.arguments = [
-                    str(arg).replace(f"{key}", str(value))
-                    for arg in element_to_act_on.arguments or []
-                    for key, value in variables.items()
-                ]
+                replaced_args = []
+                for arg in element_to_act_on.arguments or []:
+                    replaced = str(arg)
+                    for key, value in variables.items():
+                        if f"%{key}%" in replaced:
+                            replaced = replaced.replace(f"%{key}%", str(value))
+                        else:
+                            replaced = replaced.replace(key, str(value))
+                    replaced_args.append(replaced)
+                element_to_act_on.arguments = replaced_args
 
             # domSettleTimeoutMs might come from options if specified for act
             dom_settle_timeout_ms = options.get("dom_settle_timeout_ms")

--- a/stagehand/llm/prompts.py
+++ b/stagehand/llm/prompts.py
@@ -205,7 +205,7 @@ If the action implies choosing an option from a dropdown, AND the corresponding 
 If the action implies choosing an option from a dropdown, and the corresponding element is NOT a 'select' element, choose the click method."""
 
     if variables and len(variables) > 0:
-        variables_prompt = f"The following variables are available to use in the action: {', '.join(variables.keys())}. Fill the argument variables with the variable name."
+        variables_prompt = f"The following variables are available to use in the action: {', '.join(variables.keys())}. Fill the argument variables with the variable name. Wrap the argument in % symbols."
         instruction += f" {variables_prompt}"
 
     return instruction


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized string-substitution and prompt-text changes; main risk is accidental over-replacement of argument strings if variable keys overlap with normal text.
> 
> **Overview**
> `act` argument variable substitution now supports both `%name%` placeholders (preferred) and legacy unwrapped `name` replacement, avoiding the previous nested-comprehension behavior that could duplicate/over-replace arguments.
> 
> The LLM `build_act_observe_prompt` instructions are updated to ask for variables to be wrapped in `%…%`, and the package version is bumped to `0.5.11`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ce4efd1ec2fdec05cba940bcd8c370d0e49af87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept both %-wrapped and plain variable placeholders in act arguments for reliable substitution and fewer mismatches. Updated the act prompt to ask for %-wrapped variables, and bumped the package to 0.5.11.

<sup>Written for commit 9ce4efd1ec2fdec05cba940bcd8c370d0e49af87. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand-python/pull/311">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

