### PR TITLE
Add tests for model options shape as string or object

### DIFF
--- a/src/stagehand/types/session_execute_params.py
+++ b/src/stagehand/types/session_execute_params.py
@@ -56,11 +56,8 @@ class AgentConfig(TypedDict, total=False):
     mode: Literal["dom", "hybrid", "cua"]
     """Tool mode for the agent (dom, hybrid, cua). If set, overrides cua."""
 
-    model: ModelConfigParam
-    """
-    Model name string with provider prefix (e.g., 'openai/gpt-5-nano',
-    'anthropic/claude-4.5-opus')
-    """
+    model: AgentConfigModel
+    """Model configuration object or model name string (e.g., 'openai/gpt-5-nano')"""
 
     provider: Literal["openai", "anthropic", "google", "microsoft", "bedrock"]
     """AI provider for the agent (legacy, use model: openai/gpt-5-nano instead)"""

--- a/src/stagehand/types/session_extract_params.py
+++ b/src/stagehand/types/session_extract_params.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Optional
-from typing_extensions import Literal, Required, Annotated, TypedDict
+from typing_extensions import Literal, Required, Annotated, TypeAlias, TypedDict
 
 from .._utils import PropertyInfo
 from .model_config_param import ModelConfigParam
 
-__all__ = ["SessionExtractParamsBase", "Options", "SessionExtractParamsNonStreaming", "SessionExtractParamsStreaming"]
+__all__ = [
+    "SessionExtractParamsBase",
+    "Options",
+    "OptionsModel",
+    "SessionExtractParamsNonStreaming",
+    "SessionExtractParamsStreaming",
+]
 
 
 class SessionExtractParamsBase(TypedDict, total=False):
@@ -27,12 +33,12 @@ class SessionExtractParamsBase(TypedDict, total=False):
     """Whether to stream the response via SSE"""
 
 
+OptionsModel: TypeAlias = Union[ModelConfigParam, str]
+
+
 class Options(TypedDict, total=False):
-    model: ModelConfigParam
-    """
-    Model name string with provider prefix (e.g., 'openai/gpt-5-nano',
-    'anthropic/claude-4.5-opus')
-    """
+    model: OptionsModel
+    """Model configuration object or model name string (e.g., 'openai/gpt-5-nano')"""
 
     selector: str
     """CSS selector to scope extraction to a specific element"""

--- a/src/stagehand/types/session_observe_params.py
+++ b/src/stagehand/types/session_observe_params.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Optional
-from typing_extensions import Literal, Required, Annotated, TypedDict
+from typing_extensions import Literal, Required, Annotated, TypeAlias, TypedDict
 
 from .._utils import PropertyInfo
 from .model_config_param import ModelConfigParam
@@ -11,6 +11,7 @@ from .model_config_param import ModelConfigParam
 __all__ = [
     "SessionObserveParamsBase",
     "Options",
+    "OptionsModel",
     "OptionsVariables",
     "OptionsVariablesUnionMember3",
     "SessionObserveParamsNonStreaming",
@@ -30,6 +31,10 @@ class SessionObserveParamsBase(TypedDict, total=False):
     x_stream_response: Annotated[Literal["true", "false"], PropertyInfo(alias="x-stream-response")]
     """Whether to stream the response via SSE"""
 
+
+OptionsModel: TypeAlias = Union[ModelConfigParam, str]
+
+
 class OptionsVariablesUnionMember3(TypedDict, total=False):
     value: Required[Union[str, float, bool]]
 
@@ -40,11 +45,8 @@ OptionsVariables: TypeAlias = Union[str, float, bool, OptionsVariablesUnionMembe
 
 
 class Options(TypedDict, total=False):
-    model: ModelConfigParam
-    """
-    Model name string with provider prefix (e.g., 'openai/gpt-5-nano',
-    'anthropic/claude-4.5-opus')
-    """
+    model: OptionsModel
+    """Model configuration object or model name string (e.g., 'openai/gpt-5-nano')"""
 
     selector: str
     """CSS selector to scope observation to a specific element"""

--- a/src/stagehand/types/session_observe_params.py
+++ b/src/stagehand/types/session_observe_params.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Optional
-from typing_extensions import Literal, Required, Annotated, TypeAlias, TypedDict
+from typing_extensions import Literal, Required, Annotated, TypedDict
 
 from .._utils import PropertyInfo
 from .model_config_param import ModelConfigParam
@@ -11,7 +11,6 @@ from .model_config_param import ModelConfigParam
 __all__ = [
     "SessionObserveParamsBase",
     "Options",
-    "OptionsModel",
     "OptionsVariables",
     "OptionsVariablesUnionMember3",
     "SessionObserveParamsNonStreaming",
@@ -30,10 +29,6 @@ class SessionObserveParamsBase(TypedDict, total=False):
 
     x_stream_response: Annotated[Literal["true", "false"], PropertyInfo(alias="x-stream-response")]
     """Whether to stream the response via SSE"""
-
-
-OptionsModel: TypeAlias = Union[ModelConfigParam, str]
-
 
 class OptionsVariablesUnionMember3(TypedDict, total=False):
     value: Required[Union[str, float, bool]]

--- a/src/stagehand/types/session_start_params.py
+++ b/src/stagehand/types/session_start_params.py
@@ -29,11 +29,7 @@ __all__ = [
 
 class SessionStartParams(TypedDict, total=False):
     model_name: Required[Annotated[str, PropertyInfo(alias="modelName")]]
-    """Model name to use for AI operations.
-
-    Always use the format 'provider/model-name' (e.g., 'openai/gpt-4o',
-    'anthropic/claude-sonnet-4-5-20250929', 'google/gemini-2.0-flash')
-    """
+    """Model name to use for AI operations"""
 
     act_timeout_ms: Annotated[float, PropertyInfo(alias="actTimeoutMs")]
     """Timeout in ms for act operations (deprecated, v2 only)"""

--- a/tests/test_session_model_config_params.py
+++ b/tests/test_session_model_config_params.py
@@ -1,0 +1,288 @@
+# Manually maintained tests for model config request serialization.
+
+from __future__ import annotations
+
+import os
+import json
+from typing import Any, cast
+
+import httpx
+import pytest
+from respx import MockRouter
+from respx.models import Call
+
+from stagehand import Stagehand, AsyncStagehand
+
+base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
+
+MODEL_STRING = "openai/gpt-5-nano"
+MODEL_OBJECT_INPUT = {
+    "model_name": "openai/gpt-5-nano",
+    "api_key": "sk-some-openai-api-key",
+    "base_url": "https://api.openai.com/v1",
+    "headers": {"x-foo": "bar"},
+    "provider": "openai",
+}
+MODEL_OBJECT_WIRE = {
+    "modelName": "openai/gpt-5-nano",
+    "apiKey": "sk-some-openai-api-key",
+    "baseURL": "https://api.openai.com/v1",
+    "headers": {"x-foo": "bar"},
+    "provider": "openai",
+}
+
+
+def _mock_start_route(respx_mock: MockRouter, session_id: str) -> None:
+    respx_mock.post("/v1/sessions/start").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"available": True, "sessionId": session_id}},
+        )
+    )
+
+
+def _mock_observe_route(respx_mock: MockRouter, session_id: str):
+    return respx_mock.post(f"/v1/sessions/{session_id}/observe").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "success": True,
+                "data": {"result": [{"description": "Click submit", "selector": "button[type=submit]"}]},
+            },
+        )
+    )
+
+
+def _mock_extract_route(respx_mock: MockRouter, session_id: str):
+    return respx_mock.post(f"/v1/sessions/{session_id}/extract").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"result": {"value": "ok"}}},
+        )
+    )
+
+
+def _mock_execute_route(respx_mock: MockRouter, session_id: str):
+    return respx_mock.post(f"/v1/sessions/{session_id}/agentExecute").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "success": True,
+                "data": {"result": {"actions": [], "completed": True, "message": "done", "success": True}},
+            },
+        )
+    )
+
+
+def _request_json(call: Call) -> dict[str, object]:
+    return cast(dict[str, object], json.loads(call.request.content))
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_session_start_serializes_string_model_name(respx_mock: MockRouter, client: Stagehand) -> None:
+    session_id = "00000000-0000-0000-0000-000000000010"
+    start_route = respx_mock.post("/v1/sessions/start").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"available": True, "sessionId": session_id}},
+        )
+    )
+
+    session = client.sessions.start(model_name=MODEL_STRING)
+
+    assert session.id == session_id
+    request_body = _request_json(cast(Call, start_route.calls[0]))
+    assert request_body["modelName"] == MODEL_STRING
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_session_observe_serializes_string_and_object_model(respx_mock: MockRouter, client: Stagehand) -> None:
+    session_id = "00000000-0000-0000-0000-000000000011"
+    _mock_start_route(respx_mock, session_id)
+    observe_route = _mock_observe_route(respx_mock, session_id)
+
+    session = client.sessions.start(model_name=MODEL_STRING)
+
+    session.observe(instruction="find the submit button", options={"model": MODEL_STRING})
+    session.observe(
+        instruction="find the submit button",
+        options=cast(Any, {"model": MODEL_OBJECT_INPUT}),
+    )
+
+    first_request = _request_json(cast(Call, observe_route.calls[0]))
+    second_request = _request_json(cast(Call, observe_route.calls[1]))
+    assert cast(dict[str, object], first_request["options"])["model"] == MODEL_STRING
+    assert cast(dict[str, object], second_request["options"])["model"] == MODEL_OBJECT_WIRE
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_session_extract_serializes_string_and_object_model(respx_mock: MockRouter, client: Stagehand) -> None:
+    session_id = "00000000-0000-0000-0000-000000000012"
+    _mock_start_route(respx_mock, session_id)
+    extract_route = _mock_extract_route(respx_mock, session_id)
+
+    session = client.sessions.start(model_name=MODEL_STRING)
+
+    session.extract(
+        instruction="extract the result",
+        schema={"type": "object", "properties": {"value": {"type": "string"}}},
+        options={"model": MODEL_STRING},
+    )
+    session.extract(
+        instruction="extract the result",
+        schema={"type": "object", "properties": {"value": {"type": "string"}}},
+        options=cast(Any, {"model": MODEL_OBJECT_INPUT}),
+    )
+
+    first_request = _request_json(cast(Call, extract_route.calls[0]))
+    second_request = _request_json(cast(Call, extract_route.calls[1]))
+    assert cast(dict[str, object], first_request["options"])["model"] == MODEL_STRING
+    assert cast(dict[str, object], second_request["options"])["model"] == MODEL_OBJECT_WIRE
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_session_execute_serializes_string_and_object_models(respx_mock: MockRouter, client: Stagehand) -> None:
+    session_id = "00000000-0000-0000-0000-000000000013"
+    _mock_start_route(respx_mock, session_id)
+    execute_route = _mock_execute_route(respx_mock, session_id)
+
+    session = client.sessions.start(model_name=MODEL_STRING)
+
+    session.execute(
+        agent_config=cast(
+            Any,
+            {
+                "model": MODEL_STRING,
+                "execution_model": MODEL_OBJECT_INPUT,
+            },
+        ),
+        execute_options={"instruction": "click submit"},
+    )
+    session.execute(
+        agent_config=cast(
+            Any,
+            {
+                "model": MODEL_OBJECT_INPUT,
+                "execution_model": MODEL_STRING,
+            },
+        ),
+        execute_options={"instruction": "click submit"},
+    )
+
+    first_request = _request_json(cast(Call, execute_route.calls[0]))
+    second_request = _request_json(cast(Call, execute_route.calls[1]))
+    first_agent_config = cast(dict[str, object], first_request["agentConfig"])
+    second_agent_config = cast(dict[str, object], second_request["agentConfig"])
+    assert first_agent_config["model"] == MODEL_STRING
+    assert first_agent_config["executionModel"] == MODEL_OBJECT_WIRE
+    assert second_agent_config["model"] == MODEL_OBJECT_WIRE
+    assert second_agent_config["executionModel"] == MODEL_STRING
+
+
+@pytest.mark.respx(base_url=base_url)
+async def test_async_session_start_serializes_string_model_name(
+    respx_mock: MockRouter, async_client: AsyncStagehand
+) -> None:
+    session_id = "00000000-0000-0000-0000-000000000014"
+    start_route = respx_mock.post("/v1/sessions/start").mock(
+        return_value=httpx.Response(
+            200,
+            json={"success": True, "data": {"available": True, "sessionId": session_id}},
+        )
+    )
+
+    session = await async_client.sessions.start(model_name=MODEL_STRING)
+
+    assert session.id == session_id
+    request_body = _request_json(cast(Call, start_route.calls[0]))
+    assert request_body["modelName"] == MODEL_STRING
+
+
+@pytest.mark.respx(base_url=base_url)
+async def test_async_session_observe_serializes_string_and_object_model(
+    respx_mock: MockRouter, async_client: AsyncStagehand
+) -> None:
+    session_id = "00000000-0000-0000-0000-000000000015"
+    _mock_start_route(respx_mock, session_id)
+    observe_route = _mock_observe_route(respx_mock, session_id)
+
+    session = await async_client.sessions.start(model_name=MODEL_STRING)
+
+    await session.observe(instruction="find the submit button", options={"model": MODEL_STRING})
+    await session.observe(
+        instruction="find the submit button",
+        options=cast(Any, {"model": MODEL_OBJECT_INPUT}),
+    )
+
+    first_request = _request_json(cast(Call, observe_route.calls[0]))
+    second_request = _request_json(cast(Call, observe_route.calls[1]))
+    assert cast(dict[str, object], first_request["options"])["model"] == MODEL_STRING
+    assert cast(dict[str, object], second_request["options"])["model"] == MODEL_OBJECT_WIRE
+
+
+@pytest.mark.respx(base_url=base_url)
+async def test_async_session_extract_serializes_string_and_object_model(
+    respx_mock: MockRouter, async_client: AsyncStagehand
+) -> None:
+    session_id = "00000000-0000-0000-0000-000000000016"
+    _mock_start_route(respx_mock, session_id)
+    extract_route = _mock_extract_route(respx_mock, session_id)
+
+    session = await async_client.sessions.start(model_name=MODEL_STRING)
+
+    await session.extract(
+        instruction="extract the result",
+        schema={"type": "object", "properties": {"value": {"type": "string"}}},
+        options={"model": MODEL_STRING},
+    )
+    await session.extract(
+        instruction="extract the result",
+        schema={"type": "object", "properties": {"value": {"type": "string"}}},
+        options=cast(Any, {"model": MODEL_OBJECT_INPUT}),
+    )
+
+    first_request = _request_json(cast(Call, extract_route.calls[0]))
+    second_request = _request_json(cast(Call, extract_route.calls[1]))
+    assert cast(dict[str, object], first_request["options"])["model"] == MODEL_STRING
+    assert cast(dict[str, object], second_request["options"])["model"] == MODEL_OBJECT_WIRE
+
+
+@pytest.mark.respx(base_url=base_url)
+async def test_async_session_execute_serializes_string_and_object_models(
+    respx_mock: MockRouter, async_client: AsyncStagehand
+) -> None:
+    session_id = "00000000-0000-0000-0000-000000000017"
+    _mock_start_route(respx_mock, session_id)
+    execute_route = _mock_execute_route(respx_mock, session_id)
+
+    session = await async_client.sessions.start(model_name=MODEL_STRING)
+
+    await session.execute(
+        agent_config=cast(
+            Any,
+            {
+                "model": MODEL_STRING,
+                "execution_model": MODEL_OBJECT_INPUT,
+            },
+        ),
+        execute_options={"instruction": "click submit"},
+    )
+    await session.execute(
+        agent_config=cast(
+            Any,
+            {
+                "model": MODEL_OBJECT_INPUT,
+                "execution_model": MODEL_STRING,
+            },
+        ),
+        execute_options={"instruction": "click submit"},
+    )
+
+    first_request = _request_json(cast(Call, execute_route.calls[0]))
+    second_request = _request_json(cast(Call, execute_route.calls[1]))
+    first_agent_config = cast(dict[str, object], first_request["agentConfig"])
+    second_agent_config = cast(dict[str, object], second_request["agentConfig"])
+    assert first_agent_config["model"] == MODEL_STRING
+    assert first_agent_config["executionModel"] == MODEL_OBJECT_WIRE
+    assert second_agent_config["model"] == MODEL_OBJECT_WIRE
+    assert second_agent_config["executionModel"] == MODEL_STRING

--- a/uv.lock
+++ b/uv.lock
@@ -1335,7 +1335,7 @@ wheels = [
 
 [[package]]
 name = "stagehand"
-version = "3.19.3"
+version = "3.19.4"
 source = { editable = "." }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add tests confirming model options can be passed as a string or as a config object, and update types to accept both. Ensures correct request serialization for sync and async session APIs.

- **Refactors**
  - Added `OptionsModel` alias and updated `AgentConfig`/`Options` to accept `Union[ModelConfigParam, str]`; simplified docstrings.
  - Added tests for `.start`, `.observe`, `.extract`, and `.execute` (sync and async) to validate camel-cased wire keys and mixed model shapes.

- **Dependencies**
  - Bumped `stagehand` to `3.19.4` in `uv.lock`.

<sup>Written for commit 1f9ae2ec96c4f99e7f613964b9118507e3dd8a1f. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand-python/pull/339">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

