### PR TITLE
fix: make SEA binary cache writes concurrency-safe

### DIFF
--- a/src/stagehand/_custom/sea_binary.py
+++ b/src/stagehand/_custom/sea_binary.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import os
 import sys
-import hashlib
 import platform
+import tempfile
 import importlib.resources as importlib_resources
 from pathlib import Path
 from contextlib import suppress
@@ -71,9 +71,21 @@ def _copy_to_cache(*, src: Path, filename: str, version: str) -> Path:
         return dst
 
     data = src.read_bytes()
-    tmp = cache_root / f".{filename}.{hashlib.sha256(data).hexdigest()}.tmp"
-    tmp.write_bytes(data)
-    tmp.replace(dst)
+    with tempfile.NamedTemporaryFile(dir=cache_root, prefix=f".{filename}.", suffix=".tmp", delete=False) as file:
+        file.write(data)
+        tmp = Path(file.name)
+
+    try:
+        try:
+            tmp.replace(dst)
+        except OSError:
+            # Another process may have populated the cache first. Its atomic
+            # replace guarantees that an existing destination is complete.
+            if not dst.exists():
+                raise
+    finally:
+        tmp.unlink(missing_ok=True)
+
     _ensure_executable(dst)
     return dst
 

--- a/tests/test_sea_binary.py
+++ b/tests/test_sea_binary.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -21,6 +22,37 @@ def _load_download_binary_module():
 
 
 download_binary = _load_download_binary_module()
+
+
+def test_copy_to_cache_reuses_existing_binary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.write_bytes(b"new")
+    cached = tmp_path / "cache" / "test" / "stagehand-test"
+    cached.parent.mkdir(parents=True)
+    cached.write_bytes(b"cached")
+    monkeypatch.setattr(sea_binary, "_cache_dir", lambda: tmp_path / "cache")
+
+    result = sea_binary._copy_to_cache(src=source, filename="stagehand-test", version="test")
+
+    assert result == cached
+    assert result.read_bytes() == b"cached"
+
+
+def test_copy_to_cache_is_safe_when_called_concurrently(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.write_bytes(b"binary" * 1_000_000)
+    monkeypatch.setattr(sea_binary, "_cache_dir", lambda: tmp_path / "cache")
+
+    def copy(_index: int) -> Path:
+        return sea_binary._copy_to_cache(src=source, filename="stagehand-test", version="test")
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        results = list(executor.map(copy, range(16)))
+
+    expected = tmp_path / "cache" / "test" / "stagehand-test"
+    assert results == [expected] * 16
+    assert expected.read_bytes() == source.read_bytes()
+    assert list(expected.parent.glob("*.tmp")) == []
 
 
 def test_resolve_binary_path_defaults_cache_version_to_package_version(


### PR DESCRIPTION
## Summary

- write downloaded SEA binaries to unique temporary files in the cache directory
- atomically publish completed downloads and tolerate another process winning the cache race
- clean up temporary artifacts on both success and failure
- add regression coverage for concurrent writers and existing-cache behavior

## Testing

- `uv run --frozen pytest tests/test_sea_binary.py -q` (6 passed)
- `uv run --frozen ruff check .`
- `uv run --frozen pyright -p .`
- `uv run --frozen mypy --platform linux .`
- full Python 3.9 and 3.14 suites run on Windows; only the pre-existing Windows failures addressed by #355 remained

Fixes #351

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SEA binary cache writes concurrency-safe. Previously concurrent writers shared a temp path and could race, leading to partial or orphaned files; now each writer uses a unique temp file, publishes atomically, and cleans up. Fixes #351.

- Write downloaded SEA binaries to unique temp files in the cache directory via `tempfile.NamedTemporaryFile`.
- Atomically replace the destination; if another process already populated the cache, keep that file.
- Always remove temp files, on both success and failure.
- Add regression tests for existing-cache reuse and concurrent writers.

<sup>Written for commit c4b682c646f22a7e8d6079cf12b1859d21640e6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand-python/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

