### PR TITLE
fix: publish ARM64 local-mode wheels

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,6 +20,10 @@ jobs:
             binary_name: stagehand-server-v3-linux-x64
             output_path: src/stagehand/_sea/stagehand-linux-x64
             wheel_platform_tag: manylinux2014_x86_64
+          - os: ubuntu-latest
+            binary_name: stagehand-server-v3-linux-arm64
+            output_path: src/stagehand/_sea/stagehand-linux-arm64
+            wheel_platform_tag: manylinux2014_aarch64
           - os: macos-latest
             binary_name: stagehand-server-v3-darwin-arm64
             output_path: src/stagehand/_sea/stagehand-darwin-arm64
@@ -32,6 +36,10 @@ jobs:
             binary_name: stagehand-server-v3-win32-x64.exe
             output_path: src/stagehand/_sea/stagehand-win32-x64.exe
             wheel_platform_tag: win_amd64
+          - os: windows-latest
+            binary_name: stagehand-server-v3-win32-arm64.exe
+            output_path: src/stagehand/_sea/stagehand-win32-arm64.exe
+            wheel_platform_tag: win_arm64
 
     runs-on: ${{ matrix.os }}
     permissions:

--- a/tests/test_sea_binary.py
+++ b/tests/test_sea_binary.py
@@ -23,6 +23,27 @@ def _load_download_binary_module():
 download_binary = _load_download_binary_module()
 
 
+@pytest.mark.parametrize(
+    ("sys_platform", "machine", "expected"),
+    [
+        ("linux", "aarch64", "stagehand-linux-arm64"),
+        ("linux", "x86_64", "stagehand-linux-x64"),
+        ("win32", "ARM64", "stagehand-win32-arm64.exe"),
+        ("win32", "AMD64", "stagehand-win32-x64.exe"),
+    ],
+)
+def test_default_binary_filename_matches_published_wheel(
+    monkeypatch: pytest.MonkeyPatch,
+    sys_platform: str,
+    machine: str,
+    expected: str,
+) -> None:
+    monkeypatch.setattr(sea_binary.sys, "platform", sys_platform)
+    monkeypatch.setattr(sea_binary.platform, "machine", lambda: machine)
+
+    assert sea_binary.default_binary_filename() == expected
+
+
 def test_resolve_binary_path_defaults_cache_version_to_package_version(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- add Linux ARM64 and Windows ARM64 wheel targets to the publish matrix
- map those targets to the SEA asset names already produced by the release pipeline
- add resolver tests for x64 and ARM64 filenames on Linux and Windows

The packaging jobs only download and bundle architecture-specific assets, so the existing hosted x64 runners can produce these pure-Python platform-tagged wheels without executing the bundled binary.

## Testing

- `uv run --frozen pytest tests/test_sea_binary.py -q` (8 passed)
- `uv run --frozen ruff check .`
- `uv run --frozen pyright -p .`
- `uv run --frozen mypy --platform linux .`
- full Python 3.9 and 3.14 suites run on Windows; only the pre-existing Windows failures addressed by #355 remained

Fixes #352

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes ARM64 wheels for Linux and Windows in local mode. Previously we only shipped x64 wheels; now we also build manylinux2014_aarch64 and win_arm64 to enable ARM64 installs without source builds.

- Map new matrix entries to existing SEA assets: stagehand-server-v3-linux-arm64 and stagehand-server-v3-win32-arm64.exe.
- Add tests that assert default binary filenames for Linux and Windows on x64 and ARM64.
- Use hosted x64 runners only; packaging downloads architecture-specific assets and does not execute them. No runtime behavior change.

<sup>Written for commit 5f9511527e6284bb508c7a4c846e3b5f4f733748. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand-python/pull/359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

