### PR TITLE
fix: correct SEA binary setup instructions

### DIFF
--- a/src/stagehand/_custom/sea_binary.py
+++ b/src/stagehand/_custom/sea_binary.py
@@ -113,10 +113,10 @@ def resolve_binary_path(
         raise FileNotFoundError(
             f"Stagehand SEA binary not found at {candidate}.\n"
             f"For local development, download the binary using:\n"
-            f"  uv run python scripts/download-binary.py\n"
+            f"  uv run python scripts/download_binary.py\n"
             f"Or set the STAGEHAND_SEA_BINARY environment variable to point to your binary.\n"
             f"For production use, install a platform-specific wheel from PyPI.\n"
-            f"See: https://github.com/browserbase/stagehand-python#local-development"
+            f"See: https://github.com/browserbase/stagehand-python/blob/main/CONTRIBUTING.md"
         )
 
     _ensure_executable(candidate)

--- a/tests/test_sea_binary.py
+++ b/tests/test_sea_binary.py
@@ -87,3 +87,21 @@ def test_resolve_latest_server_tag_ignores_dev_releases(
     monkeypatch.setattr(download_binary, "_http_get_json", _fake_http_get_json)
 
     assert download_binary.resolve_latest_server_tag() == "stagehand-server-v3/v3.19.1"
+
+
+def test_missing_binary_error_uses_valid_download_instructions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("STAGEHAND_SEA_BINARY", raising=False)
+
+    def _missing_resource(_filename: str) -> None:
+        return None
+
+    monkeypatch.setattr(sea_binary, "_resource_binary_path", _missing_resource)
+    monkeypatch.setattr(sea_binary, "default_binary_filename", lambda: "missing-stagehand-binary")
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        sea_binary.resolve_binary_path()
+
+    message = str(exc_info.value)
+    assert "uv run python scripts/download_binary.py" in message
+    assert "scripts/download-binary.py" not in message
+    assert "blob/main/CONTRIBUTING.md" in message


### PR DESCRIPTION
## Summary

- point missing-binary errors to the existing `scripts/download_binary.py` helper
- replace the stale README anchor with the local-development documentation in `CONTRIBUTING.md`
- add a regression assertion for both actionable references

## Testing

- `uv run --frozen pytest tests/test_sea_binary.py -q` (5 passed)
- `uv run --frozen ruff check .`
- `uv run --frozen pyright -p .`
- `uv run --frozen mypy --platform linux .`
- full Python 3.9 and 3.14 suites run on Windows; only the pre-existing Windows failures addressed by #355 remained

Fixes #353

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects SEA missing-binary error guidance so local development instructions are accurate. Previously the error pointed to a non-existent script and a stale README anchor; it now references the correct helper script and `CONTRIBUTING.md`. No behavior change beyond error text.

- Error now suggests: "uv run python scripts/download_binary.py" (replaces "scripts/download-binary.py").
- Updates the help link to `https://github.com/browserbase/stagehand-python/blob/main/CONTRIBUTING.md`.
- Adds a regression test asserting both the command and link in the error message.

Fixes #353.

<sup>Written for commit a25a20e570d69d87ee4931870eb65985a3bc1224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand-python/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

