### PR TITLE
fix: persist packaged SEA binaries during extraction

### DIFF
--- a/src/stagehand/_custom/sea_binary.py
+++ b/src/stagehand/_custom/sea_binary.py
@@ -43,7 +43,7 @@ def _ensure_executable(path: Path) -> None:
         path.chmod(mode | 0o100)
 
 
-def _resource_binary_path(filename: str) -> Path | None:
+def _resource_binary_path(filename: str, *, version: str) -> Path | None:
     # Expect binaries to live at stagehand/_sea/<filename> inside the installed package.
     try:
         root = importlib_resources.files("stagehand")
@@ -58,7 +58,9 @@ def _resource_binary_path(filename: str) -> Path | None:
         return None
 
     with importlib_resources.as_file(candidate) as extracted:
-        return extracted
+        # ZIP-backed resources are temporary and disappear when this context
+        # exits, so persist the binary before returning its path.
+        return _copy_to_cache(src=extracted, filename=filename, version=version)
 
 
 def _copy_to_cache(*, src: Path, filename: str, version: str) -> Path:
@@ -97,12 +99,11 @@ def resolve_binary_path(
     filename = default_binary_filename()
 
     # Prefer packaged resources (works for wheel installs).
-    resource_path = _resource_binary_path(filename)
+    if version is None:
+        version = os.environ.get("STAGEHAND_VERSION") or __version__
+    resource_path = _resource_binary_path(filename, version=version)
     if resource_path is not None:
-        # Best-effort versioning to keep cached binaries stable across upgrades.
-        if version is None:
-            version = os.environ.get("STAGEHAND_VERSION") or __version__
-        return _copy_to_cache(src=resource_path, filename=filename, version=version)
+        return resource_path
 
     # Fallback: source checkout layout (works for local dev in-repo).
     here = Path(__file__).resolve()

--- a/tests/test_sea_binary.py
+++ b/tests/test_sea_binary.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from contextlib import contextmanager
+from collections.abc import Iterator
 
 import pytest
 
@@ -37,25 +39,53 @@ def test_resolve_binary_path_defaults_cache_version_to_package_version(
     monkeypatch.delenv("STAGEHAND_SEA_BINARY", raising=False)
     monkeypatch.delenv("STAGEHAND_VERSION", raising=False)
 
-    def _fake_resource_binary_path(_filename: str) -> Path:
+    def _fake_resource_binary_path(_filename: str, *, version: str) -> Path:
+        captured["version"] = version
         return resource_path
 
     monkeypatch.setattr(sea_binary, "_resource_binary_path", _fake_resource_binary_path)
 
-    def _fake_copy_to_cache(*, src: Path, filename: str, version: str) -> Path:
-        captured["src"] = src
-        captured["filename"] = filename
-        captured["version"] = version
-        return tmp_path / "cache" / filename
-
-    monkeypatch.setattr(sea_binary, "_copy_to_cache", _fake_copy_to_cache)
-
     resolved = sea_binary.resolve_binary_path()
 
-    assert resolved == tmp_path / "cache" / sea_binary.default_binary_filename()
-    assert captured["src"] == resource_path
-    assert captured["filename"] == sea_binary.default_binary_filename()
+    assert resolved == resource_path
     assert captured["version"] == __version__
+
+
+def test_resolve_binary_path_caches_resource_before_context_exits(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeResource:
+        def joinpath(self, _name: str) -> FakeResource:
+            return self
+
+        def is_file(self) -> bool:
+            return True
+
+    extracted = tmp_path / "temporary-binary"
+
+    @contextmanager
+    def fake_as_file(_resource: object) -> Iterator[Path]:
+        extracted.write_bytes(b"binary")
+        try:
+            yield extracted
+        finally:
+            extracted.unlink()
+
+    def fake_files(_package: str) -> FakeResource:
+        return FakeResource()
+
+    monkeypatch.delenv("STAGEHAND_SEA_BINARY", raising=False)
+    monkeypatch.setattr(sea_binary.importlib_resources, "files", fake_files)
+    monkeypatch.setattr(sea_binary.importlib_resources, "as_file", fake_as_file)
+    monkeypatch.setattr(sea_binary, "_cache_dir", lambda: tmp_path / "cache")
+    monkeypatch.setattr(sea_binary, "default_binary_filename", lambda: "stagehand-test")
+
+    resolved = sea_binary.resolve_binary_path(version="test")
+
+    assert resolved == tmp_path / "cache" / "test" / "stagehand-test"
+    assert resolved.read_bytes() == b"binary"
+    assert not extracted.exists()
 
 
 def test_parse_server_tag_rejects_prerelease_tags() -> None:


### PR DESCRIPTION
## Summary

- copy packaged SEA resources into the persistent cache while the `importlib.resources.as_file()` context is active
- return the cached path instead of an extraction path that may already have been removed
- add a regression test that simulates temporary resource cleanup on context exit

## Testing

- `uv run --frozen pytest tests/test_sea_binary.py -q` (5 passed)
- `uv run --frozen ruff check .`
- `uv run --frozen pyright -p .`
- `uv run --frozen mypy --platform linux .`
- full Python 3.9 and 3.14 suites run on Windows; only the pre-existing Windows failures addressed by #355 remained

Fixes #354

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist packaged SEA binaries during extraction so resolve_binary_path returns a stable, cached path. Previously it returned a temporary extraction path that could be deleted when the `as_file` context exited; now it copies to a versioned cache during that context and returns the cached path. Fixes #354.

- Persist the resource to the versioned cache inside the extraction context and return the cached path.
- Keep env override and source checkout fallbacks unchanged.
- Add a regression test that simulates cleanup on context exit.

<sup>Written for commit 64f0711bf8603cd8f61827f42c0c9de6c994bde1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand-python/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

