### PR TITLE
fix: warn when async client cleanup is skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,10 +295,10 @@ from stagehand import AsyncStagehand
 
 
 async def main() -> None:
-    client = AsyncStagehand()
-    session = await client.sessions.start(model_name="anthropic/claude-sonnet-4-6")
-    response = await session.act(input="click the first link on the page")
-    print(response.data)
+    async with AsyncStagehand() as client:
+        session = await client.sessions.start(model_name="anthropic/claude-sonnet-4-6")
+        response = await session.act(input="click the first link on the page")
+        print(response.data)
 
 
 asyncio.run(main())
@@ -677,7 +677,9 @@ client.with_options(http_client=DefaultHttpxClient(...))
 
 ### Managing HTTP resources
 
-By default the library closes underlying HTTP connections whenever the client is [garbage collected](https://docs.python.org/3/reference/datamodel.html#object.__del__). You can manually close the client using the `.close()` method if desired, or with a context manager that closes when exiting.
+The synchronous client makes a best effort to close underlying HTTP connections when it is [garbage collected](https://docs.python.org/3/reference/datamodel.html#object.__del__). You can close it deterministically with `.close()` or a context manager.
+
+Async clients cannot reliably close connections during garbage collection when no event loop is running. Always use `async with AsyncStagehand(...)` or call `await client.close()`.
 
 ```py
 from stagehand import Stagehand

--- a/src/stagehand/_base_client.py
+++ b/src/stagehand/_base_client.py
@@ -1419,7 +1419,23 @@ class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
 
         try:
             # TODO(someday): support non asyncio runtimes here
-            asyncio.get_running_loop().create_task(self.aclose())
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                warnings.warn(
+                    "Unclosed async HTTP client; use `async with AsyncStagehand(...)` or `await client.close()`",
+                    ResourceWarning,
+                    stacklevel=2,
+                    source=self,
+                )
+            except Exception:
+                pass
+            return
+        except Exception:
+            return
+
+        try:
+            loop.create_task(self.aclose())
         except Exception:
             pass
 

--- a/tests/test_async_client_cleanup.py
+++ b/tests/test_async_client_cleanup.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import asyncio
+import warnings
+
+import pytest
+
+from stagehand._base_client import AsyncHttpxClientWrapper
+
+
+def test_unclosed_async_http_client_warns_without_running_loop() -> None:
+    client = AsyncHttpxClientWrapper()
+
+    with pytest.warns(ResourceWarning, match="Unclosed async HTTP client"):
+        client.__del__()
+
+    asyncio.run(client.aclose())
+
+
+def test_closed_async_http_client_does_not_warn() -> None:
+    client = AsyncHttpxClientWrapper()
+    asyncio.run(client.aclose())
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        client.__del__()
+
+    assert caught == []


### PR DESCRIPTION
## Summary

- emit a `ResourceWarning` when an unclosed async HTTP client is collected without a running event loop
- continue scheduling asynchronous cleanup when a loop is available
- document explicit `async with` / `await client.close()` resource management
- add warning and clean-close regression tests

## Testing

- `uv run --frozen pytest tests/test_async_client_cleanup.py -q` (2 passed)
- `uv run --frozen ruff check .`
- `uv run --frozen pyright -p .`
- `uv run --frozen mypy --platform linux .`
- full Python 3.9 and 3.14 suites run on Windows; remaining platform failures are addressed by #355

Fixes #356

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when async async-client cleanup is skipped to prevent silent connection leaks. Previously `AsyncHttpxClientWrapper.__del__` silently did nothing if no event loop was running; now it emits a `ResourceWarning` in that case and still schedules `aclose()` when a loop exists. README examples now use `async with` to show explicit lifecycle management, with tests covering both paths.

- **Migration**
  - Use `async with AsyncStagehand(...)` or `await client.close()` to shut down async clients deterministically and avoid `ResourceWarning`.

<sup>Written for commit 87a7b0316d6ceb2f650b83d7e0bfa7731d218ef5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand-python/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

